### PR TITLE
Fix reading of S3 ACL environment variable

### DIFF
--- a/packages/director/src/screenshots/s3/config.ts
+++ b/packages/director/src/screenshots/s3/config.ts
@@ -1,4 +1,4 @@
 export const S3_BUCKET = process.env.S3_BUCKET || 'sorry-cypress';
 export const S3_REGION = process.env.S3_REGION || 'us-east-1';
-export const S3_ACL = process.env.S3_REGION || 'public-read';
+export const S3_ACL = process.env.S3_ACL || 'public-read';
 export const S3_READ_URL_PREFIX = process.env.S3_READ_URL_PREFIX || null;


### PR DESCRIPTION
The fix for #48  has an issue in reading the S3_ACL environment variable. This PR fixes that.