### PR TITLE
Fix runs query resolver to match schema

### DIFF
--- a/packages/api/src/datasources/runs.ts
+++ b/packages/api/src/datasources/runs.ts
@@ -113,7 +113,7 @@ export class RunsAPI extends DataSource {
       .aggregate(aggregationPipeline)
       .toArray();
 
-    return runFeedReducer(results);
+    return fullRunReducer(results);
   }
 
   async getRunById(id: string) {


### PR DESCRIPTION
The query `runs` returns an error stating `Expected Iterable, but did not find one for field Query.runs.`  as the object returned from the resolver does not match the Query schema. So I fixed the getAllRuns api to use the `fullRunReducer` instead of the `runFeedReducer`
fixes #62 