### PR TITLE
Add support for custom key prefixes for s3 uploads

### DIFF
--- a/packages/director/src/screenshots/s3/config.ts
+++ b/packages/director/src/screenshots/s3/config.ts
@@ -2,3 +2,5 @@ export const S3_BUCKET = process.env.S3_BUCKET || 'sorry-cypress';
 export const S3_REGION = process.env.S3_REGION || 'us-east-1';
 export const S3_ACL = process.env.S3_ACL || 'public-read';
 export const S3_READ_URL_PREFIX = process.env.S3_READ_URL_PREFIX || null;
+export const S3_IMAGE_KEY_PREFIX = process.env.S3_IMAGE_KEY_PREFIX || null;
+export const S3_VIDEO_KEY_PREFIX = process.env.S3_VIDEO_KEY_PREFIX || null;

--- a/packages/director/src/screenshots/s3/s3.ts
+++ b/packages/director/src/screenshots/s3/s3.ts
@@ -1,5 +1,5 @@
 import aws from 'aws-sdk';
-import { S3_BUCKET, S3_REGION, S3_ACL, S3_READ_URL_PREFIX } from './config';
+import { S3_BUCKET, S3_REGION, S3_ACL, S3_READ_URL_PREFIX, S3_IMAGE_KEY_PREFIX, S3_VIDEO_KEY_PREFIX } from './config';
 import { S3SignedUploadResult } from './types';
 import { AssetUploadInstruction } from '@src/types';
 
@@ -17,6 +17,22 @@ interface GetUploadURLParams {
   ContentType?: string;
   Expires?: number;
 }
+
+const sanitizeKeyPrefix = (prefix: string): string => {
+  if (prefix == null) {
+    return '';
+  }
+  let sanitizedPrefix = prefix.trim().replace(/(\/\/+)/g, '/');
+
+  if (sanitizedPrefix.startsWith('/')) {
+    sanitizedPrefix = sanitizedPrefix.substring(1);
+  }
+  if (sanitizedPrefix.endsWith('/')) {
+    return sanitizedPrefix;
+  }
+  return sanitizedPrefix + '/';
+}
+
 export const getUploadUrl = async ({
   key,
   ContentType = ImageContentType,
@@ -49,13 +65,13 @@ export const getUploadUrl = async ({
 
 export const getImageUploadUrl = async (
   key: string
-): Promise<AssetUploadInstruction> => getUploadUrl({ key: `${key}.png` });
+): Promise<AssetUploadInstruction> => getUploadUrl({ key: `${sanitizeKeyPrefix(S3_IMAGE_KEY_PREFIX)}${key}.png` });
 
 export const getVideoUploadUrl = async (
   key: string
 ): Promise<AssetUploadInstruction> =>
   getUploadUrl({
-    key: `${key}.mp4`,
+    key: `${sanitizeKeyPrefix(S3_VIDEO_KEY_PREFIX)}${key}.mp4`,
     ContentType: VideoContentType,
     Expires: 90,
   });


### PR DESCRIPTION
Add the following config options to s3 driver to add custom upload key prefixes, this should help segregate images and videos.
- S3_IMAGE_KEY_PREFIX
- S3_VIDEO_KEY_PREFIX

Also please update the s3 wiki with the following: 

**`S3_IMAGE_KEY_PREFIX`**

The prefix to use when uploading the screenshots.
Setting S3_IMAGE_KEY_PREFIX to `images` will change the generated S3 object key for screenshots to `images/${key}`.

`S3_IMAGE_KEY_PREFIX=<null>`

**`S3_VIDEO_KEY_PREFIX`**

The prefix to use when uploading the videos.
Setting S3_VIDEO_KEY_PREFIX to `videos` will change the generated S3 object key for videos to `videos/${key}`.

`S3_VIDEO_KEY_PREFIX=<null>`

