### PR TITLE
Adding auto reload toggle and tooltips on breadcrumbs

### DIFF
--- a/packages/dashboard/src/components/layout/header.tsx
+++ b/packages/dashboard/src/components/layout/header.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import truncate from 'lodash.truncate';
 import { Link } from 'react-router-dom';
-import { useCss, Breadcrumbs } from 'bold-ui';
+import { useCss, Breadcrumbs, Switch, Icon, Tooltip } from 'bold-ui';
 import { useQuery } from '@apollo/react-hooks';
 import gql from 'graphql-tag';
 
@@ -17,22 +17,49 @@ const GET_NAV_STRUCTURE = gql`
 export const Header: React.FC = () => {
   const { css, theme } = useCss();
   const { data } = useQuery(GET_NAV_STRUCTURE);
-
+  const shouldAutoRefresh = Boolean(JSON.parse(window.localStorage.getItem('shouldAutoRefresh')));
+  const lastNavItem = data.navStructure.pop();
   return (
     <header
       className={css`
         padding: 32px;
         background-color: ${theme.pallete.gray.c90};
+        display: flex;
       `}
     >
-      <Breadcrumbs>
-        <Link to="/">All Runs</Link>
-        {data.navStructure.map(navItem => (
-          <Link key={navItem.link} to={`/${navItem.link}`}>
-            {truncate(navItem.label)}
+      <div>
+        <Breadcrumbs>
+          <Link to="/">All Runs</Link>
+          {/*breadcrumb removes hover event from the last crumb so the there is a little hackery to get the tooltip working*/}
+          {data.navStructure.map(navItem => (
+            <Tooltip text={navItem.label} key={navItem.link}>
+              <Link to={`/${navItem.link}`}>
+                {truncate(navItem.label)}
+              </Link>
+            </Tooltip>
+          ))}
+          <span> </span>
+        </Breadcrumbs>
+      </div>
+      <div className={css`flex:1;`}>
+        <Tooltip text={lastNavItem?.label}>
+          <Link to={`/${lastNavItem?.link}`}>
+            {truncate(lastNavItem?.label)}
           </Link>
-        ))}
-      </Breadcrumbs>
+        </Tooltip>
+      </div>
+      <Switch label="Auto Refresh" checked={shouldAutoRefresh} onChange={()=>{
+        window.localStorage.setItem('shouldAutoRefresh', !shouldAutoRefresh);
+        window.location.reload();
+      }}/>
+      &nbsp;
+      <Tooltip text="Toggle polling the api for updates.">
+        <Icon
+          className={css`align-self: center;`}
+          icon="infoCircleOutline"
+          size={1}
+        />
+      </Tooltip>
     </header>
   );
 };

--- a/packages/dashboard/src/components/layout/header.tsx
+++ b/packages/dashboard/src/components/layout/header.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
-import truncate from 'lodash.truncate';
-import { Link } from 'react-router-dom';
-import { useCss, Breadcrumbs, Switch, Icon, Tooltip } from 'bold-ui';
 import { useQuery } from '@apollo/react-hooks';
+import { useAutoRefresh } from '@src/hooks/useAutoRefresh';
+import { Breadcrumbs, Icon, Switch, Tooltip, useCss } from 'bold-ui';
 import gql from 'graphql-tag';
+import truncate from 'lodash.truncate';
+import React from 'react';
+import { Link } from 'react-router-dom';
 
 const GET_NAV_STRUCTURE = gql`
   {
@@ -17,7 +18,8 @@ const GET_NAV_STRUCTURE = gql`
 export const Header: React.FC = () => {
   const { css, theme } = useCss();
   const { data } = useQuery(GET_NAV_STRUCTURE);
-  const shouldAutoRefresh = Boolean(JSON.parse(window.localStorage.getItem('shouldAutoRefresh')));
+  const [shouldAutoRefresh, setShouldAutoRefresh] = useAutoRefresh();
+
   const lastNavItem = data.navStructure.pop();
   return (
     <header
@@ -31,31 +33,39 @@ export const Header: React.FC = () => {
         <Breadcrumbs>
           <Link to="/">All Runs</Link>
           {/*breadcrumb removes hover event from the last crumb so the there is a little hackery to get the tooltip working*/}
-          {data.navStructure.map(navItem => (
+          {data.navStructure.map((navItem) => (
             <Tooltip text={navItem.label} key={navItem.link}>
-              <Link to={`/${navItem.link}`}>
-                {truncate(navItem.label)}
-              </Link>
+              <Link to={`/${navItem.link}`}>{truncate(navItem.label)}</Link>
             </Tooltip>
           ))}
           <span> </span>
         </Breadcrumbs>
       </div>
-      <div className={css`flex:1;`}>
+      <div
+        className={css`
+          flex: 1;
+        `}
+      >
         <Tooltip text={lastNavItem?.label}>
           <Link to={`/${lastNavItem?.link}`}>
             {truncate(lastNavItem?.label)}
           </Link>
         </Tooltip>
       </div>
-      <Switch label="Auto Refresh" checked={shouldAutoRefresh} onChange={()=>{
-        window.localStorage.setItem('shouldAutoRefresh', !shouldAutoRefresh);
-        window.location.reload();
-      }}/>
+      <Switch
+        label="Auto Refresh"
+        checked={shouldAutoRefresh}
+        onChange={() => {
+          setShouldAutoRefresh(!shouldAutoRefresh);
+          window.location.reload();
+        }}
+      />
       &nbsp;
       <Tooltip text="Toggle polling the api for updates.">
         <Icon
-          className={css`align-self: center;`}
+          className={css`
+            align-self: center;
+          `}
           icon="infoCircleOutline"
           size={1}
         />

--- a/packages/dashboard/src/hooks/useAutoRefresh.ts
+++ b/packages/dashboard/src/hooks/useAutoRefresh.ts
@@ -1,0 +1,4 @@
+import { useLocalStorage } from './useLocalStorage';
+
+export const useAutoRefresh = () =>
+  useLocalStorage<boolean>('shouldAutoRefresh', false);

--- a/packages/dashboard/src/hooks/useLocalStorage.ts
+++ b/packages/dashboard/src/hooks/useLocalStorage.ts
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+
+// https://usehooks.com/useLocalStorage/
+interface SetLocalStorageValue<T> {
+  (value: T): void;
+  (value: (valueS: T) => T): void;
+}
+export function useLocalStorage<T>(
+  key: string,
+  initialValue: T
+): [T, SetLocalStorageValue<T>] {
+  const _key = `sorry:${key}`;
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    try {
+      // Get from local storage by key
+      const item = window.localStorage.getItem(_key);
+      // Parse stored json or if none return initialValue
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      // If error also return initialValue
+      console.log(error);
+      return initialValue;
+    }
+  });
+
+  // Return a wrapped version of useState's setter function that ...
+  // ... persists the new value to localStorage.
+  const setValue = (value: T) => {
+    try {
+      // Allow value to be a function so we have same API as useState
+      const valueToStore =
+        value instanceof Function ? value(storedValue) : value;
+      // Save state
+      setStoredValue(valueToStore);
+      // Save to local storage
+      window.localStorage.setItem(_key, JSON.stringify(valueToStore));
+    } catch (error) {
+      // A more advanced implementation would handle the error case
+      console.log(error);
+    }
+  };
+
+  return [storedValue, setValue as SetLocalStorageValue<T>];
+}

--- a/packages/dashboard/src/views/InstanceDetailsView.tsx
+++ b/packages/dashboard/src/views/InstanceDetailsView.tsx
@@ -16,9 +16,11 @@ export function InstanceDetailsView({
     params: { id },
   },
 }: InstanceDetailsViewProps): React.ReactNode {
+  const shouldAutoRefresh = Boolean(JSON.parse(window.localStorage.getItem('shouldAutoRefresh')));
+  
   const { loading, error, data } = useGetInstanceQuery({
     variables: { instanceId: id },
-    pollInterval: 1500,
+    pollInterval: shouldAutoRefresh ? 1500 : undefined,
   });
   const apollo = useApolloClient();
 

--- a/packages/dashboard/src/views/InstanceDetailsView.tsx
+++ b/packages/dashboard/src/views/InstanceDetailsView.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import { InstanceSummary } from '../components/instance/summary';
-import { InstanceDetails } from '../components/instance/details';
-import { useGetInstanceQuery } from '../generated/graphql';
 import { useApolloClient } from '@apollo/react-hooks';
+import { useAutoRefresh } from '@src/hooks/useAutoRefresh';
+import React from 'react';
+import { InstanceDetails } from '../components/instance/details';
+import { InstanceSummary } from '../components/instance/summary';
+import { useGetInstanceQuery } from '../generated/graphql';
 
 type InstanceDetailsViewProps = {
   match: {
@@ -16,8 +17,8 @@ export function InstanceDetailsView({
     params: { id },
   },
 }: InstanceDetailsViewProps): React.ReactNode {
-  const shouldAutoRefresh = Boolean(JSON.parse(window.localStorage.getItem('shouldAutoRefresh')));
-  
+  const [shouldAutoRefresh] = useAutoRefresh();
+
   const { loading, error, data } = useGetInstanceQuery({
     variables: { instanceId: id },
     pollInterval: shouldAutoRefresh ? 1500 : undefined,

--- a/packages/dashboard/src/views/RunDetailsView.tsx
+++ b/packages/dashboard/src/views/RunDetailsView.tsx
@@ -18,9 +18,11 @@ export function RunDetailsView({
 }: RunDetailsViewProps): React.ReactNode {
   const apollo = useApolloClient();
 
+  const shouldAutoRefresh = Boolean(JSON.parse(window.localStorage.getItem('shouldAutoRefresh')));
+
   const { loading, error, data } = useGetRunQuery({
     variables: { runId: id },
-    pollInterval: 1500,
+    pollInterval: shouldAutoRefresh ? 1500 : undefined,
   });
 
   if (loading) return <p>Loading...</p>;

--- a/packages/dashboard/src/views/RunDetailsView.tsx
+++ b/packages/dashboard/src/views/RunDetailsView.tsx
@@ -1,8 +1,9 @@
+import { useApolloClient } from '@apollo/react-hooks';
+import { useAutoRefresh } from '@src/hooks/useAutoRefresh';
 import React from 'react';
 import { RunDetails } from '../components/run/details';
 import { RunSummary } from '../components/run/summary';
 import { useGetRunQuery } from '../generated/graphql';
-import { useApolloClient } from '@apollo/react-hooks';
 
 type RunDetailsViewProps = {
   match: {
@@ -18,7 +19,7 @@ export function RunDetailsView({
 }: RunDetailsViewProps): React.ReactNode {
   const apollo = useApolloClient();
 
-  const shouldAutoRefresh = Boolean(JSON.parse(window.localStorage.getItem('shouldAutoRefresh')));
+  const [shouldAutoRefresh] = useAutoRefresh();
 
   const { loading, error, data } = useGetRunQuery({
     variables: { runId: id },

--- a/packages/dashboard/src/views/TestDetailsView.tsx
+++ b/packages/dashboard/src/views/TestDetailsView.tsx
@@ -1,13 +1,14 @@
+import { useApolloClient } from '@apollo/react-hooks';
+import { useAutoRefresh } from '@src/hooks/useAutoRefresh';
 import React from 'react';
 import { Link, useParams } from 'react-router-dom';
-import { useGetInstanceQuery } from '../generated/graphql';
-import { useApolloClient } from '@apollo/react-hooks';
 import { TestDetails } from '../components/test';
+import { useGetInstanceQuery } from '../generated/graphql';
 
 export function TestDetailsView(): React.ReactNode {
   const { instanceId, testId } = useParams();
 
-  const shouldAutoRefresh = Boolean(JSON.parse(window.localStorage.getItem('shouldAutoRefresh')));
+  const [shouldAutoRefresh] = useAutoRefresh();
 
   const { loading, error, data } = useGetInstanceQuery({
     variables: { instanceId },

--- a/packages/dashboard/src/views/TestDetailsView.tsx
+++ b/packages/dashboard/src/views/TestDetailsView.tsx
@@ -7,9 +7,11 @@ import { TestDetails } from '../components/test';
 export function TestDetailsView(): React.ReactNode {
   const { instanceId, testId } = useParams();
 
+  const shouldAutoRefresh = Boolean(JSON.parse(window.localStorage.getItem('shouldAutoRefresh')));
+
   const { loading, error, data } = useGetInstanceQuery({
     variables: { instanceId },
-    pollInterval: 1500,
+    pollInterval: shouldAutoRefresh ? 1500 : undefined,
   });
 
   const apollo = useApolloClient();


### PR DESCRIPTION
I did not do anything with the auto refresh on the runs page. Due to the stuff with load more. If we switch that to pagination hopefully that will be simple to implement.

![Screen Shot 2020-08-07 at 5 18 42 PM](https://user-images.githubusercontent.com/5297942/89695676-18dba100-d8d2-11ea-9d72-65a9e9ac27ca.png)
![Screen Shot 2020-08-07 at 5 17 55 PM](https://user-images.githubusercontent.com/5297942/89695678-1a0cce00-d8d2-11ea-90c4-d001d99aa0e9.png)


Also on a side note for global state are we planning to just use apollo cache? If so maybe I can migrate the local storage updating and such to somewhere in the application bootstrap.