### PR TITLE
Add heuristics to run view.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
   },
 
   rules: {
+    '@typescript-eslint/no-unused-vars': 'error',
     '@typescript-eslint/explicit-member-accessibility': 0,
     '@typescript-eslint/explicit-function-return-type': 0,
     '@typescript-eslint/no-non-null-assertion': 1,

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn run lint && pretty-quick --staged"
+      "pre-commit": "yarn run lint && pretty-quick"
     }
   },
   "dependencies": {

--- a/packages/api/src/datasources/runs.ts
+++ b/packages/api/src/datasources/runs.ts
@@ -118,7 +118,6 @@ export class RunsAPI extends DataSource {
       lookupAggregation,
     ]).filter((i) => !!i);
 
-    console.log(JSON.stringify(aggregationPipeline))
     const results = await getMongoDB()
       .collection('runs')
       .aggregate(aggregationPipeline)

--- a/packages/api/src/datasources/runs.ts
+++ b/packages/api/src/datasources/runs.ts
@@ -43,16 +43,16 @@ const getSortByAggregation = (direction = 'DESC') => ({
   },
 });
 
-const filtersToAggreations = (filters)=>{
-  return filters ? filters.map((filter)=>{
-    const mapkeys = filter.key.split('.');
-    return {
-      $match: {
-        [filter.key]:filter.value
-      }
-    }
-  }) : []
-
+const filtersToAggregations = (filters) => {
+  return filters
+    ? filters.map((filter) => {
+        return {
+          $match: {
+            [filter.key]: filter.value,
+          },
+        };
+      })
+    : [];
 };
 
 const projectAggregation = {
@@ -112,11 +112,13 @@ export class RunsAPI extends DataSource {
   }
 
   async getAllRuns({ orderDirection, filters }) {
-    const aggregationPipeline = filtersToAggreations(filters).concat([
-      getSortByAggregation(orderDirection),
-      projectAggregation,
-      lookupAggregation,
-    ]).filter((i) => !!i);
+    const aggregationPipeline = filtersToAggregations(filters)
+      .concat([
+        getSortByAggregation(orderDirection),
+        projectAggregation,
+        lookupAggregation,
+      ])
+      .filter((i) => !!i);
 
     const results = await getMongoDB()
       .collection('runs')

--- a/packages/api/src/datasources/runs.ts
+++ b/packages/api/src/datasources/runs.ts
@@ -43,6 +43,18 @@ const getSortByAggregation = (direction = 'DESC') => ({
   },
 });
 
+const filtersToAggreations = (filters)=>{
+  return filters ? filters.map((filter)=>{
+    const mapkeys = filter.key.split('.');
+    return {
+      $match: {
+        [filter.key]:filter.value
+      }
+    }
+  }) : []
+
+};
+
 const projectAggregation = {
   $project: {
     _id: 1,
@@ -99,13 +111,14 @@ export class RunsAPI extends DataSource {
     return runFeedReducer(results);
   }
 
-  async getAllRuns({ orderDirection }) {
-    const aggregationPipeline = [
+  async getAllRuns({ orderDirection, filters }) {
+    const aggregationPipeline = filtersToAggreations(filters).concat([
       getSortByAggregation(orderDirection),
       projectAggregation,
       lookupAggregation,
-    ].filter((i) => !!i);
+    ]).filter((i) => !!i);
 
+    console.log(JSON.stringify(aggregationPipeline))
     const results = await getMongoDB()
       .collection('runs')
       .aggregate(aggregationPipeline)

--- a/packages/api/src/generated/graphql.ts
+++ b/packages/api/src/generated/graphql.ts
@@ -1,7 +1,16 @@
-import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
+import {
+  GraphQLResolveInfo,
+  GraphQLScalarType,
+  GraphQLScalarTypeConfig,
+} from 'graphql';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
-export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
+export type Exact<T extends { [key: string]: unknown }> = {
+  [K in keyof T]: T[K];
+};
+export type RequireFields<T, K extends keyof T> = {
+  [X in Exclude<keyof T, K>]?: T[X];
+} &
+  { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -27,7 +36,6 @@ export type CypressConfig = {
   video: Scalars['Boolean'];
   videoUploadOnPasses: Scalars['Boolean'];
 };
-
 
 export type DeleteRunResponse = {
   __typename?: 'DeleteRunResponse';
@@ -114,16 +122,13 @@ export type Mutation = {
   deleteRunsInDateRange: DeleteRunResponse;
 };
 
-
 export type MutationDeleteRunArgs = {
   runId: Scalars['ID'];
 };
 
-
 export type MutationDeleteRunsArgs = {
   runIds: Array<Maybe<Scalars['ID']>>;
 };
-
 
 export type MutationDeleteRunsInDateRangeArgs = {
   startDate: Scalars['DateTime'];
@@ -132,7 +137,7 @@ export type MutationDeleteRunsInDateRangeArgs = {
 
 export enum OrderingOptions {
   Desc = 'DESC',
-  Asc = 'ASC'
+  Asc = 'ASC',
 }
 
 export type PartialRun = {
@@ -151,23 +156,19 @@ export type Query = {
   instance?: Maybe<Instance>;
 };
 
-
 export type QueryRunsArgs = {
   orderDirection?: Maybe<OrderingOptions>;
   cursor?: Maybe<Scalars['String']>;
   filters?: Maybe<Array<Maybe<Filters>>>;
 };
 
-
 export type QueryRunFeedArgs = {
   cursor?: Maybe<Scalars['String']>;
 };
 
-
 export type QueryRunArgs = {
   id: Scalars['ID'];
 };
-
 
 export type QueryInstanceArgs = {
   id: Scalars['ID'];
@@ -216,10 +217,7 @@ export type RunSpec = {
   claimedAt?: Maybe<Scalars['String']>;
 };
 
-
-
 export type ResolverTypeWrapper<T> = Promise<T> | T;
-
 
 export type LegacyStitchingResolver<TResult, TParent, TContext, TArgs> = {
   fragment: string;
@@ -230,7 +228,9 @@ export type NewStitchingResolver<TResult, TParent, TContext, TArgs> = {
   selectionSet: string;
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
 };
-export type StitchingResolver<TResult, TParent, TContext, TArgs> = LegacyStitchingResolver<TResult, TParent, TContext, TArgs> | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
+export type StitchingResolver<TResult, TParent, TContext, TArgs> =
+  | LegacyStitchingResolver<TResult, TParent, TContext, TArgs>
+  | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
 export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
   | ResolverFn<TResult, TParent, TContext, TArgs>
   | StitchingResolver<TResult, TParent, TContext, TArgs>;
@@ -256,9 +256,25 @@ export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
   info: GraphQLResolveInfo
 ) => TResult | Promise<TResult>;
 
-export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
-  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
-  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
+export interface SubscriptionSubscriberObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> {
+  subscribe: SubscriptionSubscribeFn<
+    { [key in TKey]: TResult },
+    TParent,
+    TContext,
+    TArgs
+  >;
+  resolve?: SubscriptionResolveFn<
+    TResult,
+    { [key in TKey]: TResult },
+    TContext,
+    TArgs
+  >;
 }
 
 export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
@@ -266,12 +282,26 @@ export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
   resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
 }
 
-export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+export type SubscriptionObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> =
   | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
   | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
 
-export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
-  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+export type SubscriptionResolver<
+  TResult,
+  TKey extends string,
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> =
+  | ((
+      ...args: any[]
+    ) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
   | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
 
 export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
@@ -280,11 +310,19 @@ export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
   info: GraphQLResolveInfo
 ) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
 
-export type IsTypeOfResolverFn<T = {}> = (obj: T, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
+export type IsTypeOfResolverFn<T = {}> = (
+  obj: T,
+  info: GraphQLResolveInfo
+) => boolean | Promise<boolean>;
 
 export type NextResolverFn<T> = () => Promise<T>;
 
-export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
+export type DirectiveResolverFn<
+  TResult = {},
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> = (
   next: NextResolverFn<TResult>,
   parent: TParent,
   args: TArgs,
@@ -347,121 +385,276 @@ export type ResolversParentTypes = {
   DeleteRunResponse: DeleteRunResponse;
 };
 
-export type CommitResolvers<ContextType = any, ParentType extends ResolversParentTypes['Commit'] = ResolversParentTypes['Commit']> = {
+export type CommitResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Commit'] = ResolversParentTypes['Commit']
+> = {
   sha?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   branch?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  authorName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  authorEmail?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  authorName?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  authorEmail?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
   message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  remoteOrigin?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  remoteOrigin?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type CypressConfigResolvers<ContextType = any, ParentType extends ResolversParentTypes['CypressConfig'] = ResolversParentTypes['CypressConfig']> = {
+export type CypressConfigResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['CypressConfig'] = ResolversParentTypes['CypressConfig']
+> = {
   video?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  videoUploadOnPasses?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  videoUploadOnPasses?: Resolver<
+    ResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export interface DateTimeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['DateTime'], any> {
+export interface DateTimeScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes['DateTime'], any> {
   name: 'DateTime';
 }
 
-export type DeleteRunResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['DeleteRunResponse'] = ResolversParentTypes['DeleteRunResponse']> = {
+export type DeleteRunResponseResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['DeleteRunResponse'] = ResolversParentTypes['DeleteRunResponse']
+> = {
   success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  runIds?: Resolver<Array<Maybe<ResolversTypes['ID']>>, ParentType, ContextType>;
+  runIds?: Resolver<
+    Array<Maybe<ResolversTypes['ID']>>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type FullRunSpecResolvers<ContextType = any, ParentType extends ResolversParentTypes['FullRunSpec'] = ResolversParentTypes['FullRunSpec']> = {
+export type FullRunSpecResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['FullRunSpec'] = ResolversParentTypes['FullRunSpec']
+> = {
   spec?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   instanceId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   claimed?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  claimedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  results?: Resolver<Maybe<ResolversTypes['InstanceResults']>, ParentType, ContextType>;
+  claimedAt?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  results?: Resolver<
+    Maybe<ResolversTypes['InstanceResults']>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type InstanceResolvers<ContextType = any, ParentType extends ResolversParentTypes['Instance'] = ResolversParentTypes['Instance']> = {
+export type InstanceResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Instance'] = ResolversParentTypes['Instance']
+> = {
   runId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   run?: Resolver<ResolversTypes['PartialRun'], ParentType, ContextType>;
   spec?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   instanceId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  results?: Resolver<Maybe<ResolversTypes['InstanceResults']>, ParentType, ContextType>;
+  results?: Resolver<
+    Maybe<ResolversTypes['InstanceResults']>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type InstanceResultsResolvers<ContextType = any, ParentType extends ResolversParentTypes['InstanceResults'] = ResolversParentTypes['InstanceResults']> = {
+export type InstanceResultsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['InstanceResults'] = ResolversParentTypes['InstanceResults']
+> = {
   stats?: Resolver<ResolversTypes['InstanceStats'], ParentType, ContextType>;
-  tests?: Resolver<Maybe<Array<Maybe<ResolversTypes['InstanceTest']>>>, ParentType, ContextType>;
+  tests?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['InstanceTest']>>>,
+    ParentType,
+    ContextType
+  >;
   error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   stdout?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  screenshots?: Resolver<Array<ResolversTypes['InstanceScreeshot']>, ParentType, ContextType>;
-  cypressConfig?: Resolver<Maybe<ResolversTypes['CypressConfig']>, ParentType, ContextType>;
-  reporterStats?: Resolver<Maybe<ResolversTypes['ReporterStats']>, ParentType, ContextType>;
+  screenshots?: Resolver<
+    Array<ResolversTypes['InstanceScreeshot']>,
+    ParentType,
+    ContextType
+  >;
+  cypressConfig?: Resolver<
+    Maybe<ResolversTypes['CypressConfig']>,
+    ParentType,
+    ContextType
+  >;
+  reporterStats?: Resolver<
+    Maybe<ResolversTypes['ReporterStats']>,
+    ParentType,
+    ContextType
+  >;
   videoUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type InstanceScreeshotResolvers<ContextType = any, ParentType extends ResolversParentTypes['InstanceScreeshot'] = ResolversParentTypes['InstanceScreeshot']> = {
+export type InstanceScreeshotResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['InstanceScreeshot'] = ResolversParentTypes['InstanceScreeshot']
+> = {
   screenshotId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   testId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   takenAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   height?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   width?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  screenshotURL?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  screenshotURL?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type InstanceStatsResolvers<ContextType = any, ParentType extends ResolversParentTypes['InstanceStats'] = ResolversParentTypes['InstanceStats']> = {
+export type InstanceStatsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['InstanceStats'] = ResolversParentTypes['InstanceStats']
+> = {
   suites?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   tests?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   passes?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   pending?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   skipped?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   failures?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  wallClockStartedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  wallClockEndedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  wallClockDuration?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  wallClockStartedAt?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  wallClockEndedAt?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  wallClockDuration?: Resolver<
+    Maybe<ResolversTypes['Int']>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type InstanceTestResolvers<ContextType = any, ParentType extends ResolversParentTypes['InstanceTest'] = ResolversParentTypes['InstanceTest']> = {
+export type InstanceTestResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['InstanceTest'] = ResolversParentTypes['InstanceTest']
+> = {
   testId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  title?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
+  title?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['String']>>>,
+    ParentType,
+    ContextType
+  >;
   state?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   body?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   stack?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  wallClockStartedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  wallClockDuration?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  wallClockStartedAt?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  wallClockDuration?: Resolver<
+    Maybe<ResolversTypes['Int']>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
-  deleteRun?: Resolver<ResolversTypes['DeleteRunResponse'], ParentType, ContextType, RequireFields<MutationDeleteRunArgs, 'runId'>>;
-  deleteRuns?: Resolver<ResolversTypes['DeleteRunResponse'], ParentType, ContextType, RequireFields<MutationDeleteRunsArgs, 'runIds'>>;
-  deleteRunsInDateRange?: Resolver<ResolversTypes['DeleteRunResponse'], ParentType, ContextType, RequireFields<MutationDeleteRunsInDateRangeArgs, 'startDate' | 'endDate'>>;
+export type MutationResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']
+> = {
+  deleteRun?: Resolver<
+    ResolversTypes['DeleteRunResponse'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationDeleteRunArgs, 'runId'>
+  >;
+  deleteRuns?: Resolver<
+    ResolversTypes['DeleteRunResponse'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationDeleteRunsArgs, 'runIds'>
+  >;
+  deleteRunsInDateRange?: Resolver<
+    ResolversTypes['DeleteRunResponse'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationDeleteRunsInDateRangeArgs, 'startDate' | 'endDate'>
+  >;
 };
 
-export type PartialRunResolvers<ContextType = any, ParentType extends ResolversParentTypes['PartialRun'] = ResolversParentTypes['PartialRun']> = {
+export type PartialRunResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['PartialRun'] = ResolversParentTypes['PartialRun']
+> = {
   runId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   meta?: Resolver<Maybe<ResolversTypes['RunMeta']>, ParentType, ContextType>;
-  specs?: Resolver<Array<Maybe<ResolversTypes['RunSpec']>>, ParentType, ContextType>;
+  specs?: Resolver<
+    Array<Maybe<ResolversTypes['RunSpec']>>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-  runs?: Resolver<Array<Maybe<ResolversTypes['Run']>>, ParentType, ContextType, RequireFields<QueryRunsArgs, 'orderDirection' | 'cursor' | 'filters'>>;
-  runFeed?: Resolver<ResolversTypes['RunFeed'], ParentType, ContextType, RequireFields<QueryRunFeedArgs, never>>;
-  run?: Resolver<Maybe<ResolversTypes['Run']>, ParentType, ContextType, RequireFields<QueryRunArgs, 'id'>>;
-  instance?: Resolver<Maybe<ResolversTypes['Instance']>, ParentType, ContextType, RequireFields<QueryInstanceArgs, 'id'>>;
+export type QueryResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']
+> = {
+  runs?: Resolver<
+    Array<Maybe<ResolversTypes['Run']>>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryRunsArgs, 'orderDirection' | 'cursor' | 'filters'>
+  >;
+  runFeed?: Resolver<
+    ResolversTypes['RunFeed'],
+    ParentType,
+    ContextType,
+    RequireFields<QueryRunFeedArgs, never>
+  >;
+  run?: Resolver<
+    Maybe<ResolversTypes['Run']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryRunArgs, 'id'>
+  >;
+  instance?: Resolver<
+    Maybe<ResolversTypes['Instance']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryInstanceArgs, 'id'>
+  >;
 };
 
-export type ReporterStatsResolvers<ContextType = any, ParentType extends ResolversParentTypes['ReporterStats'] = ResolversParentTypes['ReporterStats']> = {
+export type ReporterStatsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['ReporterStats'] = ResolversParentTypes['ReporterStats']
+> = {
   suites?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   tests?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   passes?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -473,34 +666,62 @@ export type ReporterStatsResolvers<ContextType = any, ParentType extends Resolve
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type RunResolvers<ContextType = any, ParentType extends ResolversParentTypes['Run'] = ResolversParentTypes['Run']> = {
+export type RunResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Run'] = ResolversParentTypes['Run']
+> = {
   runId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   meta?: Resolver<Maybe<ResolversTypes['RunMeta']>, ParentType, ContextType>;
-  specs?: Resolver<Array<Maybe<ResolversTypes['FullRunSpec']>>, ParentType, ContextType>;
+  specs?: Resolver<
+    Array<Maybe<ResolversTypes['FullRunSpec']>>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type RunFeedResolvers<ContextType = any, ParentType extends ResolversParentTypes['RunFeed'] = ResolversParentTypes['RunFeed']> = {
+export type RunFeedResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['RunFeed'] = ResolversParentTypes['RunFeed']
+> = {
   cursor?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   hasMore?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   runs?: Resolver<Array<ResolversTypes['Run']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type RunMetaResolvers<ContextType = any, ParentType extends ResolversParentTypes['RunMeta'] = ResolversParentTypes['RunMeta']> = {
+export type RunMetaResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['RunMeta'] = ResolversParentTypes['RunMeta']
+> = {
   groupId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  ciBuildId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  projectId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  ciBuildId?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  projectId?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
   commit?: Resolver<Maybe<ResolversTypes['Commit']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type RunSpecResolvers<ContextType = any, ParentType extends ResolversParentTypes['RunSpec'] = ResolversParentTypes['RunSpec']> = {
+export type RunSpecResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['RunSpec'] = ResolversParentTypes['RunSpec']
+> = {
   spec?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   instanceId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   claimed?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  claimedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  claimedAt?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
@@ -524,7 +745,6 @@ export type Resolvers<ContextType = any> = {
   RunMeta?: RunMetaResolvers<ContextType>;
   RunSpec?: RunSpecResolvers<ContextType>;
 };
-
 
 /**
  * @deprecated

--- a/packages/api/src/generated/graphql.ts
+++ b/packages/api/src/generated/graphql.ts
@@ -1,13 +1,7 @@
-import {
-  GraphQLResolveInfo,
-  GraphQLScalarType,
-  GraphQLScalarTypeConfig,
-} from 'graphql';
+import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
 export type Maybe<T> = T | null;
-export type RequireFields<T, K extends keyof T> = {
-  [X in Exclude<keyof T, K>]?: T[X];
-} &
-  { [P in K]-?: NonNullable<T[P]> };
+export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -34,11 +28,17 @@ export type CypressConfig = {
   videoUploadOnPasses: Scalars['Boolean'];
 };
 
+
 export type DeleteRunResponse = {
   __typename?: 'DeleteRunResponse';
   success: Scalars['Boolean'];
   message: Scalars['String'];
   runIds: Array<Maybe<Scalars['ID']>>;
+};
+
+export type Filters = {
+  key?: Maybe<Scalars['String']>;
+  value?: Maybe<Scalars['String']>;
 };
 
 export type FullRunSpec = {
@@ -114,13 +114,16 @@ export type Mutation = {
   deleteRunsInDateRange: DeleteRunResponse;
 };
 
+
 export type MutationDeleteRunArgs = {
   runId: Scalars['ID'];
 };
 
+
 export type MutationDeleteRunsArgs = {
   runIds: Array<Maybe<Scalars['ID']>>;
 };
+
 
 export type MutationDeleteRunsInDateRangeArgs = {
   startDate: Scalars['DateTime'];
@@ -129,7 +132,7 @@ export type MutationDeleteRunsInDateRangeArgs = {
 
 export enum OrderingOptions {
   Desc = 'DESC',
-  Asc = 'ASC',
+  Asc = 'ASC'
 }
 
 export type PartialRun = {
@@ -148,18 +151,23 @@ export type Query = {
   instance?: Maybe<Instance>;
 };
 
+
 export type QueryRunsArgs = {
   orderDirection?: Maybe<OrderingOptions>;
   cursor?: Maybe<Scalars['String']>;
+  filters?: Maybe<Array<Maybe<Filters>>>;
 };
+
 
 export type QueryRunFeedArgs = {
   cursor?: Maybe<Scalars['String']>;
 };
 
+
 export type QueryRunArgs = {
   id: Scalars['ID'];
 };
+
 
 export type QueryInstanceArgs = {
   id: Scalars['ID'];
@@ -208,13 +216,21 @@ export type RunSpec = {
   claimedAt?: Maybe<Scalars['String']>;
 };
 
+
+
 export type ResolverTypeWrapper<T> = Promise<T> | T;
 
-export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
+
+export type LegacyStitchingResolver<TResult, TParent, TContext, TArgs> = {
   fragment: string;
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
 };
 
+export type NewStitchingResolver<TResult, TParent, TContext, TArgs> = {
+  selectionSet: string;
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+export type StitchingResolver<TResult, TParent, TContext, TArgs> = LegacyStitchingResolver<TResult, TParent, TContext, TArgs> | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
 export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
   | ResolverFn<TResult, TParent, TContext, TArgs>
   | StitchingResolver<TResult, TParent, TContext, TArgs>;
@@ -240,25 +256,9 @@ export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
   info: GraphQLResolveInfo
 ) => TResult | Promise<TResult>;
 
-export interface SubscriptionSubscriberObject<
-  TResult,
-  TKey extends string,
-  TParent,
-  TContext,
-  TArgs
-> {
-  subscribe: SubscriptionSubscribeFn<
-    { [key in TKey]: TResult },
-    TParent,
-    TContext,
-    TArgs
-  >;
-  resolve?: SubscriptionResolveFn<
-    TResult,
-    { [key in TKey]: TResult },
-    TContext,
-    TArgs
-  >;
+export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
 }
 
 export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
@@ -266,26 +266,12 @@ export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
   resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
 }
 
-export type SubscriptionObject<
-  TResult,
-  TKey extends string,
-  TParent,
-  TContext,
-  TArgs
-> =
+export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
   | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
   | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
 
-export type SubscriptionResolver<
-  TResult,
-  TKey extends string,
-  TParent = {},
-  TContext = {},
-  TArgs = {}
-> =
-  | ((
-      ...args: any[]
-    ) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
+  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
   | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
 
 export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
@@ -294,19 +280,11 @@ export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
   info: GraphQLResolveInfo
 ) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
 
-export type isTypeOfResolverFn<T = {}> = (
-  obj: T,
-  info: GraphQLResolveInfo
-) => boolean | Promise<boolean>;
+export type IsTypeOfResolverFn<T = {}> = (obj: T, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
 
 export type NextResolverFn<T> = () => Promise<T>;
 
-export type DirectiveResolverFn<
-  TResult = {},
-  TParent = {},
-  TContext = {},
-  TArgs = {}
-> = (
+export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
   next: NextResolverFn<TResult>,
   parent: TParent,
   args: TArgs,
@@ -319,6 +297,7 @@ export type ResolversTypes = {
   Query: ResolverTypeWrapper<{}>;
   OrderingOptions: OrderingOptions;
   String: ResolverTypeWrapper<Scalars['String']>;
+  Filters: Filters;
   Run: ResolverTypeWrapper<Run>;
   ID: ResolverTypeWrapper<Scalars['ID']>;
   DateTime: ResolverTypeWrapper<Scalars['DateTime']>;
@@ -344,8 +323,8 @@ export type ResolversTypes = {
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
   Query: {};
-  OrderingOptions: OrderingOptions;
   String: Scalars['String'];
+  Filters: Filters;
   Run: Run;
   ID: Scalars['ID'];
   DateTime: Scalars['DateTime'];
@@ -368,276 +347,121 @@ export type ResolversParentTypes = {
   DeleteRunResponse: DeleteRunResponse;
 };
 
-export type CommitResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Commit'] = ResolversParentTypes['Commit']
-> = {
+export type CommitResolvers<ContextType = any, ParentType extends ResolversParentTypes['Commit'] = ResolversParentTypes['Commit']> = {
   sha?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   branch?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  authorName?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
-  authorEmail?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
+  authorName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  authorEmail?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  remoteOrigin?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
-  __isTypeOf?: isTypeOfResolverFn<ParentType>;
+  remoteOrigin?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type CypressConfigResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['CypressConfig'] = ResolversParentTypes['CypressConfig']
-> = {
+export type CypressConfigResolvers<ContextType = any, ParentType extends ResolversParentTypes['CypressConfig'] = ResolversParentTypes['CypressConfig']> = {
   video?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  videoUploadOnPasses?: Resolver<
-    ResolversTypes['Boolean'],
-    ParentType,
-    ContextType
-  >;
-  __isTypeOf?: isTypeOfResolverFn<ParentType>;
+  videoUploadOnPasses?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export interface DateTimeScalarConfig
-  extends GraphQLScalarTypeConfig<ResolversTypes['DateTime'], any> {
+export interface DateTimeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['DateTime'], any> {
   name: 'DateTime';
 }
 
-export type DeleteRunResponseResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['DeleteRunResponse'] = ResolversParentTypes['DeleteRunResponse']
-> = {
+export type DeleteRunResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['DeleteRunResponse'] = ResolversParentTypes['DeleteRunResponse']> = {
   success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  runIds?: Resolver<
-    Array<Maybe<ResolversTypes['ID']>>,
-    ParentType,
-    ContextType
-  >;
-  __isTypeOf?: isTypeOfResolverFn<ParentType>;
+  runIds?: Resolver<Array<Maybe<ResolversTypes['ID']>>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type FullRunSpecResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['FullRunSpec'] = ResolversParentTypes['FullRunSpec']
-> = {
+export type FullRunSpecResolvers<ContextType = any, ParentType extends ResolversParentTypes['FullRunSpec'] = ResolversParentTypes['FullRunSpec']> = {
   spec?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   instanceId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   claimed?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  claimedAt?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
-  results?: Resolver<
-    Maybe<ResolversTypes['InstanceResults']>,
-    ParentType,
-    ContextType
-  >;
-  __isTypeOf?: isTypeOfResolverFn<ParentType>;
+  claimedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  results?: Resolver<Maybe<ResolversTypes['InstanceResults']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type InstanceResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Instance'] = ResolversParentTypes['Instance']
-> = {
+export type InstanceResolvers<ContextType = any, ParentType extends ResolversParentTypes['Instance'] = ResolversParentTypes['Instance']> = {
   runId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   run?: Resolver<ResolversTypes['PartialRun'], ParentType, ContextType>;
   spec?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   instanceId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  results?: Resolver<
-    Maybe<ResolversTypes['InstanceResults']>,
-    ParentType,
-    ContextType
-  >;
-  __isTypeOf?: isTypeOfResolverFn<ParentType>;
+  results?: Resolver<Maybe<ResolversTypes['InstanceResults']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type InstanceResultsResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['InstanceResults'] = ResolversParentTypes['InstanceResults']
-> = {
+export type InstanceResultsResolvers<ContextType = any, ParentType extends ResolversParentTypes['InstanceResults'] = ResolversParentTypes['InstanceResults']> = {
   stats?: Resolver<ResolversTypes['InstanceStats'], ParentType, ContextType>;
-  tests?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['InstanceTest']>>>,
-    ParentType,
-    ContextType
-  >;
+  tests?: Resolver<Maybe<Array<Maybe<ResolversTypes['InstanceTest']>>>, ParentType, ContextType>;
   error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   stdout?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  screenshots?: Resolver<
-    Array<ResolversTypes['InstanceScreeshot']>,
-    ParentType,
-    ContextType
-  >;
-  cypressConfig?: Resolver<
-    Maybe<ResolversTypes['CypressConfig']>,
-    ParentType,
-    ContextType
-  >;
-  reporterStats?: Resolver<
-    Maybe<ResolversTypes['ReporterStats']>,
-    ParentType,
-    ContextType
-  >;
+  screenshots?: Resolver<Array<ResolversTypes['InstanceScreeshot']>, ParentType, ContextType>;
+  cypressConfig?: Resolver<Maybe<ResolversTypes['CypressConfig']>, ParentType, ContextType>;
+  reporterStats?: Resolver<Maybe<ResolversTypes['ReporterStats']>, ParentType, ContextType>;
   videoUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: isTypeOfResolverFn<ParentType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type InstanceScreeshotResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['InstanceScreeshot'] = ResolversParentTypes['InstanceScreeshot']
-> = {
+export type InstanceScreeshotResolvers<ContextType = any, ParentType extends ResolversParentTypes['InstanceScreeshot'] = ResolversParentTypes['InstanceScreeshot']> = {
   screenshotId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   testId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   takenAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   height?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   width?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  screenshotURL?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
-  __isTypeOf?: isTypeOfResolverFn<ParentType>;
+  screenshotURL?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type InstanceStatsResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['InstanceStats'] = ResolversParentTypes['InstanceStats']
-> = {
+export type InstanceStatsResolvers<ContextType = any, ParentType extends ResolversParentTypes['InstanceStats'] = ResolversParentTypes['InstanceStats']> = {
   suites?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   tests?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   passes?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   pending?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   skipped?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   failures?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  wallClockStartedAt?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
-  wallClockEndedAt?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
-  wallClockDuration?: Resolver<
-    Maybe<ResolversTypes['Int']>,
-    ParentType,
-    ContextType
-  >;
-  __isTypeOf?: isTypeOfResolverFn<ParentType>;
+  wallClockStartedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  wallClockEndedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  wallClockDuration?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type InstanceTestResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['InstanceTest'] = ResolversParentTypes['InstanceTest']
-> = {
+export type InstanceTestResolvers<ContextType = any, ParentType extends ResolversParentTypes['InstanceTest'] = ResolversParentTypes['InstanceTest']> = {
   testId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  title?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['String']>>>,
-    ParentType,
-    ContextType
-  >;
+  title?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
   state?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   body?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   stack?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  wallClockStartedAt?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
-  wallClockDuration?: Resolver<
-    Maybe<ResolversTypes['Int']>,
-    ParentType,
-    ContextType
-  >;
-  __isTypeOf?: isTypeOfResolverFn<ParentType>;
+  wallClockStartedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  wallClockDuration?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type MutationResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']
-> = {
-  deleteRun?: Resolver<
-    ResolversTypes['DeleteRunResponse'],
-    ParentType,
-    ContextType,
-    RequireFields<MutationDeleteRunArgs, 'runId'>
-  >;
-  deleteRuns?: Resolver<
-    ResolversTypes['DeleteRunResponse'],
-    ParentType,
-    ContextType,
-    RequireFields<MutationDeleteRunsArgs, 'runIds'>
-  >;
-  deleteRunsInDateRange?: Resolver<
-    ResolversTypes['DeleteRunResponse'],
-    ParentType,
-    ContextType,
-    RequireFields<MutationDeleteRunsInDateRangeArgs, 'startDate' | 'endDate'>
-  >;
+export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
+  deleteRun?: Resolver<ResolversTypes['DeleteRunResponse'], ParentType, ContextType, RequireFields<MutationDeleteRunArgs, 'runId'>>;
+  deleteRuns?: Resolver<ResolversTypes['DeleteRunResponse'], ParentType, ContextType, RequireFields<MutationDeleteRunsArgs, 'runIds'>>;
+  deleteRunsInDateRange?: Resolver<ResolversTypes['DeleteRunResponse'], ParentType, ContextType, RequireFields<MutationDeleteRunsInDateRangeArgs, 'startDate' | 'endDate'>>;
 };
 
-export type PartialRunResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['PartialRun'] = ResolversParentTypes['PartialRun']
-> = {
+export type PartialRunResolvers<ContextType = any, ParentType extends ResolversParentTypes['PartialRun'] = ResolversParentTypes['PartialRun']> = {
   runId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   meta?: Resolver<Maybe<ResolversTypes['RunMeta']>, ParentType, ContextType>;
-  specs?: Resolver<
-    Array<Maybe<ResolversTypes['RunSpec']>>,
-    ParentType,
-    ContextType
-  >;
-  __isTypeOf?: isTypeOfResolverFn<ParentType>;
+  specs?: Resolver<Array<Maybe<ResolversTypes['RunSpec']>>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type QueryResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']
-> = {
-  runs?: Resolver<
-    Array<Maybe<ResolversTypes['Run']>>,
-    ParentType,
-    ContextType,
-    RequireFields<QueryRunsArgs, 'orderDirection' | 'cursor'>
-  >;
-  runFeed?: Resolver<
-    ResolversTypes['RunFeed'],
-    ParentType,
-    ContextType,
-    RequireFields<QueryRunFeedArgs, never>
-  >;
-  run?: Resolver<
-    Maybe<ResolversTypes['Run']>,
-    ParentType,
-    ContextType,
-    RequireFields<QueryRunArgs, 'id'>
-  >;
-  instance?: Resolver<
-    Maybe<ResolversTypes['Instance']>,
-    ParentType,
-    ContextType,
-    RequireFields<QueryInstanceArgs, 'id'>
-  >;
+export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
+  runs?: Resolver<Array<Maybe<ResolversTypes['Run']>>, ParentType, ContextType, RequireFields<QueryRunsArgs, 'orderDirection' | 'cursor' | 'filters'>>;
+  runFeed?: Resolver<ResolversTypes['RunFeed'], ParentType, ContextType, RequireFields<QueryRunFeedArgs, never>>;
+  run?: Resolver<Maybe<ResolversTypes['Run']>, ParentType, ContextType, RequireFields<QueryRunArgs, 'id'>>;
+  instance?: Resolver<Maybe<ResolversTypes['Instance']>, ParentType, ContextType, RequireFields<QueryInstanceArgs, 'id'>>;
 };
 
-export type ReporterStatsResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['ReporterStats'] = ResolversParentTypes['ReporterStats']
-> = {
+export type ReporterStatsResolvers<ContextType = any, ParentType extends ResolversParentTypes['ReporterStats'] = ResolversParentTypes['ReporterStats']> = {
   suites?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   tests?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   passes?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -646,66 +470,38 @@ export type ReporterStatsResolvers<
   start?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   end?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   duration?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  __isTypeOf?: isTypeOfResolverFn<ParentType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type RunResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Run'] = ResolversParentTypes['Run']
-> = {
+export type RunResolvers<ContextType = any, ParentType extends ResolversParentTypes['Run'] = ResolversParentTypes['Run']> = {
   runId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   meta?: Resolver<Maybe<ResolversTypes['RunMeta']>, ParentType, ContextType>;
-  specs?: Resolver<
-    Array<Maybe<ResolversTypes['FullRunSpec']>>,
-    ParentType,
-    ContextType
-  >;
-  __isTypeOf?: isTypeOfResolverFn<ParentType>;
+  specs?: Resolver<Array<Maybe<ResolversTypes['FullRunSpec']>>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type RunFeedResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['RunFeed'] = ResolversParentTypes['RunFeed']
-> = {
+export type RunFeedResolvers<ContextType = any, ParentType extends ResolversParentTypes['RunFeed'] = ResolversParentTypes['RunFeed']> = {
   cursor?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   hasMore?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   runs?: Resolver<Array<ResolversTypes['Run']>, ParentType, ContextType>;
-  __isTypeOf?: isTypeOfResolverFn<ParentType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type RunMetaResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['RunMeta'] = ResolversParentTypes['RunMeta']
-> = {
+export type RunMetaResolvers<ContextType = any, ParentType extends ResolversParentTypes['RunMeta'] = ResolversParentTypes['RunMeta']> = {
   groupId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  ciBuildId?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
-  projectId?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
+  ciBuildId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  projectId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   commit?: Resolver<Maybe<ResolversTypes['Commit']>, ParentType, ContextType>;
-  __isTypeOf?: isTypeOfResolverFn<ParentType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type RunSpecResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['RunSpec'] = ResolversParentTypes['RunSpec']
-> = {
+export type RunSpecResolvers<ContextType = any, ParentType extends ResolversParentTypes['RunSpec'] = ResolversParentTypes['RunSpec']> = {
   spec?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   instanceId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   claimed?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  claimedAt?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
-  __isTypeOf?: isTypeOfResolverFn<ParentType>;
+  claimedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
 export type Resolvers<ContextType = any> = {
@@ -728,6 +524,7 @@ export type Resolvers<ContextType = any> = {
   RunMeta?: RunMetaResolvers<ContextType>;
   RunSpec?: RunSpecResolvers<ContextType>;
 };
+
 
 /**
  * @deprecated

--- a/packages/api/src/resolvers/index.ts
+++ b/packages/api/src/resolvers/index.ts
@@ -6,9 +6,11 @@ export const resolvers = {
   Query: {
     runs: (
       _,
-      { orderDirection }: { orderDirection: any },
+      { orderDirection, filters },
       { dataSources }: { dataSources: AppDatasources }
-    ) => dataSources.runsAPI.getAllRuns({ orderDirection }),
+    ) => {
+      return dataSources.runsAPI.getAllRuns({ orderDirection, filters })
+    },
     runFeed: (
       _,
       { cursor }: { cursor?: string },

--- a/packages/api/src/resolvers/index.ts
+++ b/packages/api/src/resolvers/index.ts
@@ -9,7 +9,7 @@ export const resolvers = {
       { orderDirection, filters },
       { dataSources }: { dataSources: AppDatasources }
     ) => {
-      return dataSources.runsAPI.getAllRuns({ orderDirection, filters })
+      return dataSources.runsAPI.getAllRuns({ orderDirection, filters });
     },
     runFeed: (
       _,

--- a/packages/api/src/schema/schema.graphql
+++ b/packages/api/src/schema/schema.graphql
@@ -5,8 +5,13 @@ enum OrderingOptions {
   ASC
 }
 
+input Filters {
+  key: String
+  value: String
+}
+
 type Query {
-  runs(orderDirection: OrderingOptions = DESC, cursor: String = null): [Run]!
+  runs(orderDirection: OrderingOptions = DESC, cursor: String = null, filters: [Filters] = null): [Run]!
   runFeed(cursor: String): RunFeed!
   run(id: ID!): Run
   instance(id: ID!): Instance

--- a/packages/api/src/schema/schema.graphql
+++ b/packages/api/src/schema/schema.graphql
@@ -11,7 +11,11 @@ input Filters {
 }
 
 type Query {
-  runs(orderDirection: OrderingOptions = DESC, cursor: String = null, filters: [Filters] = null): [Run]!
+  runs(
+    orderDirection: OrderingOptions = DESC
+    cursor: String = null
+    filters: [Filters] = null
+  ): [Run]!
   runFeed(cursor: String): RunFeed!
   run(id: ID!): Run
   instance(id: ID!): Instance

--- a/packages/dashboard/src/components/run/details.tsx
+++ b/packages/dashboard/src/components/run/details.tsx
@@ -8,6 +8,7 @@ import {
   Tooltip,
   useCss,
 } from 'bold-ui';
+import mean from 'lodash/mean';
 import React, { useState } from 'react';
 import { generatePath } from 'react-router-dom';
 import { FullRunSpec, Run } from '../../generated/graphql';
@@ -16,14 +17,15 @@ import { shortEnglishHumanizerWithMsIfNeeded } from '../../lib/utis';
 import { SpecState } from '../common';
 import RenderOnInterval from '../renderOnInterval/renderOnInterval';
 
-const average = averageArray => averageArray.reduce( ( accumultor, nextArrayItem ) => accumultor + nextArrayItem, 0 ) / averageArray.length;
-
 type RunDetailsProps = {
   run: Partial<Run>;
-  propertySpecHeuristics: any;
+  propertySpecHeuristics: Record<string, number[]>;
 };
 
-export function RunDetails({ run, propertySpecHeuristics = {} }: RunDetailsProps) {
+export function RunDetails({
+  run,
+  propertySpecHeuristics = {},
+}: RunDetailsProps) {
   const { css } = useCss();
   const { specs } = run;
 
@@ -125,7 +127,9 @@ export function RunDetails({ run, propertySpecHeuristics = {} }: RunDetailsProps
               sortable: false,
               render: (spec: FullRunSpec) => {
                 if (spec?.spec) {
-                  return shortEnglishHumanizerWithMsIfNeeded(average(propertySpecHeuristics[spec?.spec] || []));
+                  return shortEnglishHumanizerWithMsIfNeeded(
+                    mean(propertySpecHeuristics[spec?.spec] || [])
+                  );
                 }
               },
             },

--- a/packages/dashboard/src/components/run/details.tsx
+++ b/packages/dashboard/src/components/run/details.tsx
@@ -16,11 +16,14 @@ import { shortEnglishHumanizerWithMsIfNeeded } from '../../lib/utis';
 import { SpecState } from '../common';
 import RenderOnInterval from '../renderOnInterval/renderOnInterval';
 
+const average = averageArray => averageArray.reduce( ( accumultor, nextArrayItem ) => accumultor + nextArrayItem, 0 ) / averageArray.length;
+
 type RunDetailsProps = {
   run: Partial<Run>;
+  propertySpecHeuristics: any;
 };
 
-export function RunDetails({ run }: RunDetailsProps) {
+export function RunDetails({ run, propertySpecHeuristics = {} }: RunDetailsProps) {
   const { css } = useCss();
   const { specs } = run;
 
@@ -113,6 +116,16 @@ export function RunDetails({ run }: RunDetailsProps) {
                   );
                 } else {
                   return '';
+                }
+              },
+            },
+            {
+              name: 'average-duration',
+              header: 'Average Duration',
+              sortable: false,
+              render: (spec: FullRunSpec) => {
+                if (spec?.spec) {
+                  return shortEnglishHumanizerWithMsIfNeeded(average(propertySpecHeuristics[spec?.spec] || []));
                 }
               },
             },

--- a/packages/dashboard/src/generated/graphql.ts
+++ b/packages/dashboard/src/generated/graphql.ts
@@ -13,7 +13,7 @@ export type Scalars = {
 };
 
 export type Commit = {
-  __typename?: 'Commit';
+   __typename?: 'Commit';
   sha?: Maybe<Scalars['String']>;
   branch?: Maybe<Scalars['String']>;
   authorName?: Maybe<Scalars['String']>;
@@ -23,20 +23,26 @@ export type Commit = {
 };
 
 export type CypressConfig = {
-  __typename?: 'CypressConfig';
+   __typename?: 'CypressConfig';
   video: Scalars['Boolean'];
   videoUploadOnPasses: Scalars['Boolean'];
 };
 
+
 export type DeleteRunResponse = {
-  __typename?: 'DeleteRunResponse';
+   __typename?: 'DeleteRunResponse';
   success: Scalars['Boolean'];
   message: Scalars['String'];
   runIds: Array<Maybe<Scalars['ID']>>;
 };
 
+export type Filters = {
+  key?: Maybe<Scalars['String']>;
+  value?: Maybe<Scalars['String']>;
+};
+
 export type FullRunSpec = {
-  __typename?: 'FullRunSpec';
+   __typename?: 'FullRunSpec';
   spec: Scalars['String'];
   instanceId: Scalars['String'];
   claimed: Scalars['Boolean'];
@@ -45,7 +51,7 @@ export type FullRunSpec = {
 };
 
 export type Instance = {
-  __typename?: 'Instance';
+   __typename?: 'Instance';
   runId: Scalars['ID'];
   run: PartialRun;
   spec: Scalars['String'];
@@ -54,7 +60,7 @@ export type Instance = {
 };
 
 export type InstanceResults = {
-  __typename?: 'InstanceResults';
+   __typename?: 'InstanceResults';
   stats: InstanceStats;
   tests?: Maybe<Array<Maybe<InstanceTest>>>;
   error?: Maybe<Scalars['String']>;
@@ -66,7 +72,7 @@ export type InstanceResults = {
 };
 
 export type InstanceScreeshot = {
-  __typename?: 'InstanceScreeshot';
+   __typename?: 'InstanceScreeshot';
   screenshotId: Scalars['String'];
   name?: Maybe<Scalars['String']>;
   testId: Scalars['String'];
@@ -77,7 +83,7 @@ export type InstanceScreeshot = {
 };
 
 export type InstanceStats = {
-  __typename?: 'InstanceStats';
+   __typename?: 'InstanceStats';
   suites?: Maybe<Scalars['Int']>;
   tests?: Maybe<Scalars['Int']>;
   passes?: Maybe<Scalars['Int']>;
@@ -90,7 +96,7 @@ export type InstanceStats = {
 };
 
 export type InstanceTest = {
-  __typename?: 'InstanceTest';
+   __typename?: 'InstanceTest';
   testId: Scalars['String'];
   title?: Maybe<Array<Maybe<Scalars['String']>>>;
   state?: Maybe<Scalars['String']>;
@@ -102,19 +108,22 @@ export type InstanceTest = {
 };
 
 export type Mutation = {
-  __typename?: 'Mutation';
+   __typename?: 'Mutation';
   deleteRun: DeleteRunResponse;
   deleteRuns: DeleteRunResponse;
   deleteRunsInDateRange: DeleteRunResponse;
 };
 
+
 export type MutationDeleteRunArgs = {
   runId: Scalars['ID'];
 };
 
+
 export type MutationDeleteRunsArgs = {
   runIds: Array<Maybe<Scalars['ID']>>;
 };
+
 
 export type MutationDeleteRunsInDateRangeArgs = {
   startDate: Scalars['DateTime'];
@@ -123,11 +132,11 @@ export type MutationDeleteRunsInDateRangeArgs = {
 
 export enum OrderingOptions {
   Desc = 'DESC',
-  Asc = 'ASC',
+  Asc = 'ASC'
 }
 
 export type PartialRun = {
-  __typename?: 'PartialRun';
+   __typename?: 'PartialRun';
   runId: Scalars['ID'];
   createdAt: Scalars['DateTime'];
   meta?: Maybe<RunMeta>;
@@ -135,32 +144,37 @@ export type PartialRun = {
 };
 
 export type Query = {
-  __typename?: 'Query';
+   __typename?: 'Query';
   runs: Array<Maybe<Run>>;
   runFeed: RunFeed;
   run?: Maybe<Run>;
   instance?: Maybe<Instance>;
 };
 
+
 export type QueryRunsArgs = {
   orderDirection?: Maybe<OrderingOptions>;
   cursor?: Maybe<Scalars['String']>;
+  filters?: Maybe<Array<Maybe<Filters>>>;
 };
+
 
 export type QueryRunFeedArgs = {
   cursor?: Maybe<Scalars['String']>;
 };
 
+
 export type QueryRunArgs = {
   id: Scalars['ID'];
 };
+
 
 export type QueryInstanceArgs = {
   id: Scalars['ID'];
 };
 
 export type ReporterStats = {
-  __typename?: 'ReporterStats';
+   __typename?: 'ReporterStats';
   suites?: Maybe<Scalars['Int']>;
   tests?: Maybe<Scalars['Int']>;
   passes?: Maybe<Scalars['Int']>;
@@ -172,7 +186,7 @@ export type ReporterStats = {
 };
 
 export type Run = {
-  __typename?: 'Run';
+   __typename?: 'Run';
   runId: Scalars['ID'];
   createdAt: Scalars['DateTime'];
   meta?: Maybe<RunMeta>;
@@ -180,14 +194,14 @@ export type Run = {
 };
 
 export type RunFeed = {
-  __typename?: 'RunFeed';
+   __typename?: 'RunFeed';
   cursor: Scalars['String'];
   hasMore: Scalars['Boolean'];
   runs: Array<Run>;
 };
 
 export type RunMeta = {
-  __typename?: 'RunMeta';
+   __typename?: 'RunMeta';
   groupId?: Maybe<Scalars['String']>;
   ciBuildId?: Maybe<Scalars['String']>;
   projectId?: Maybe<Scalars['String']>;
@@ -195,7 +209,7 @@ export type RunMeta = {
 };
 
 export type RunSpec = {
-  __typename?: 'RunSpec';
+   __typename?: 'RunSpec';
   spec: Scalars['String'];
   instanceId: Scalars['String'];
   claimed: Scalars['Boolean'];
@@ -206,259 +220,174 @@ export type DeleteRunMutationVariables = {
   runId: Scalars['ID'];
 };
 
-export type DeleteRunMutation = { __typename?: 'Mutation' } & {
-  deleteRun: { __typename?: 'DeleteRunResponse' } & Pick<
-    DeleteRunResponse,
-    'success' | 'message' | 'runIds'
-  >;
-};
+
+export type DeleteRunMutation = (
+  { __typename?: 'Mutation' }
+  & { deleteRun: (
+    { __typename?: 'DeleteRunResponse' }
+    & Pick<DeleteRunResponse, 'success' | 'message' | 'runIds'>
+  ) }
+);
 
 export type GetInstanceQueryVariables = {
   instanceId: Scalars['ID'];
 };
 
-export type GetInstanceQuery = { __typename?: 'Query' } & {
-  instance?: Maybe<
-    { __typename?: 'Instance' } & Pick<
-      Instance,
-      'instanceId' | 'runId' | 'spec'
-    > & {
-        run: { __typename?: 'PartialRun' } & {
-          meta?: Maybe<
-            { __typename?: 'RunMeta' } & Pick<RunMeta, 'ciBuildId'> & {
-                commit?: Maybe<
-                  { __typename?: 'Commit' } & Pick<
-                    Commit,
-                    | 'sha'
-                    | 'branch'
-                    | 'authorName'
-                    | 'authorEmail'
-                    | 'remoteOrigin'
-                    | 'message'
-                  >
-                >;
-              }
-          >;
-        };
-        results?: Maybe<
-          { __typename?: 'InstanceResults' } & Pick<
-            InstanceResults,
-            'videoUrl'
-          > & {
-              stats: { __typename?: 'InstanceStats' } & Pick<
-                InstanceStats,
-                | 'suites'
-                | 'tests'
-                | 'passes'
-                | 'pending'
-                | 'skipped'
-                | 'failures'
-                | 'wallClockDuration'
-                | 'wallClockStartedAt'
-                | 'wallClockEndedAt'
-              >;
-              tests?: Maybe<
-                Array<
-                  Maybe<
-                    { __typename?: 'InstanceTest' } & Pick<
-                      InstanceTest,
-                      | 'testId'
-                      | 'wallClockDuration'
-                      | 'wallClockStartedAt'
-                      | 'state'
-                      | 'error'
-                      | 'stack'
-                      | 'title'
-                    >
-                  >
-                >
-              >;
-              screenshots: Array<
-                { __typename?: 'InstanceScreeshot' } & Pick<
-                  InstanceScreeshot,
-                  | 'testId'
-                  | 'screenshotId'
-                  | 'height'
-                  | 'width'
-                  | 'screenshotURL'
-                >
-              >;
-              cypressConfig?: Maybe<
-                { __typename?: 'CypressConfig' } & Pick<
-                  CypressConfig,
-                  'video' | 'videoUploadOnPasses'
-                >
-              >;
-            }
-        >;
-      }
-  >;
-};
+
+export type GetInstanceQuery = (
+  { __typename?: 'Query' }
+  & { instance?: Maybe<(
+    { __typename?: 'Instance' }
+    & Pick<Instance, 'instanceId' | 'runId' | 'spec'>
+    & { run: (
+      { __typename?: 'PartialRun' }
+      & { meta?: Maybe<(
+        { __typename?: 'RunMeta' }
+        & Pick<RunMeta, 'ciBuildId'>
+        & { commit?: Maybe<(
+          { __typename?: 'Commit' }
+          & Pick<Commit, 'sha' | 'branch' | 'authorName' | 'authorEmail' | 'remoteOrigin' | 'message'>
+        )> }
+      )> }
+    ), results?: Maybe<(
+      { __typename?: 'InstanceResults' }
+      & Pick<InstanceResults, 'videoUrl'>
+      & { stats: (
+        { __typename?: 'InstanceStats' }
+        & Pick<InstanceStats, 'suites' | 'tests' | 'passes' | 'pending' | 'skipped' | 'failures' | 'wallClockDuration' | 'wallClockStartedAt' | 'wallClockEndedAt'>
+      ), tests?: Maybe<Array<Maybe<(
+        { __typename?: 'InstanceTest' }
+        & Pick<InstanceTest, 'testId' | 'wallClockDuration' | 'wallClockStartedAt' | 'state' | 'error' | 'stack' | 'title'>
+      )>>>, screenshots: Array<(
+        { __typename?: 'InstanceScreeshot' }
+        & Pick<InstanceScreeshot, 'testId' | 'screenshotId' | 'height' | 'width' | 'screenshotURL'>
+      )>, cypressConfig?: Maybe<(
+        { __typename?: 'CypressConfig' }
+        & Pick<CypressConfig, 'video' | 'videoUploadOnPasses'>
+      )> }
+    )> }
+  )> }
+);
 
 export type GetRunQueryVariables = {
   runId: Scalars['ID'];
 };
 
-export type GetRunQuery = { __typename?: 'Query' } & {
-  run?: Maybe<
-    { __typename?: 'Run' } & Pick<Run, 'runId' | 'createdAt'> & {
-        meta?: Maybe<
-          { __typename?: 'RunMeta' } & Pick<
-            RunMeta,
-            'ciBuildId' | 'projectId'
-          > & {
-              commit?: Maybe<
-                { __typename?: 'Commit' } & Pick<
-                  Commit,
-                  | 'sha'
-                  | 'branch'
-                  | 'remoteOrigin'
-                  | 'message'
-                  | 'authorEmail'
-                  | 'authorName'
-                >
-              >;
-            }
-        >;
-        specs: Array<
-          Maybe<
-            { __typename?: 'FullRunSpec' } & Pick<
-              FullRunSpec,
-              'spec' | 'instanceId' | 'claimed' | 'claimedAt'
-            > & {
-                results?: Maybe<
-                  { __typename?: 'InstanceResults' } & Pick<
-                    InstanceResults,
-                    'videoUrl'
-                  > & {
-                      cypressConfig?: Maybe<
-                        { __typename?: 'CypressConfig' } & Pick<
-                          CypressConfig,
-                          'video' | 'videoUploadOnPasses'
-                        >
-                      >;
-                      tests?: Maybe<
-                        Array<
-                          Maybe<
-                            { __typename?: 'InstanceTest' } & Pick<
-                              InstanceTest,
-                              | 'title'
-                              | 'state'
-                              | 'wallClockDuration'
-                              | 'wallClockStartedAt'
-                            >
-                          >
-                        >
-                      >;
-                      stats: { __typename?: 'InstanceStats' } & Pick<
-                        InstanceStats,
-                        | 'tests'
-                        | 'pending'
-                        | 'passes'
-                        | 'failures'
-                        | 'skipped'
-                        | 'suites'
-                        | 'wallClockDuration'
-                        | 'wallClockStartedAt'
-                        | 'wallClockEndedAt'
-                      >;
-                    }
-                >;
-              }
-          >
-        >;
-      }
-  >;
+
+export type GetRunQuery = (
+  { __typename?: 'Query' }
+  & { run?: Maybe<(
+    { __typename?: 'Run' }
+    & Pick<Run, 'runId' | 'createdAt'>
+    & { meta?: Maybe<(
+      { __typename?: 'RunMeta' }
+      & Pick<RunMeta, 'ciBuildId' | 'projectId'>
+      & { commit?: Maybe<(
+        { __typename?: 'Commit' }
+        & Pick<Commit, 'sha' | 'branch' | 'remoteOrigin' | 'message' | 'authorEmail' | 'authorName'>
+      )> }
+    )>, specs: Array<Maybe<(
+      { __typename?: 'FullRunSpec' }
+      & Pick<FullRunSpec, 'spec' | 'instanceId' | 'claimed' | 'claimedAt'>
+      & { results?: Maybe<(
+        { __typename?: 'InstanceResults' }
+        & Pick<InstanceResults, 'videoUrl'>
+        & { cypressConfig?: Maybe<(
+          { __typename?: 'CypressConfig' }
+          & Pick<CypressConfig, 'video' | 'videoUploadOnPasses'>
+        )>, tests?: Maybe<Array<Maybe<(
+          { __typename?: 'InstanceTest' }
+          & Pick<InstanceTest, 'title' | 'state' | 'wallClockDuration' | 'wallClockStartedAt'>
+        )>>>, stats: (
+          { __typename?: 'InstanceStats' }
+          & Pick<InstanceStats, 'tests' | 'pending' | 'passes' | 'failures' | 'skipped' | 'suites' | 'wallClockDuration' | 'wallClockStartedAt' | 'wallClockEndedAt'>
+        ) }
+      )> }
+    )>> }
+  )> }
+);
+
+export type GetRunsByProjectIdLimitedToTimingQueryVariables = {
+  orderDirection?: Maybe<OrderingOptions>;
+  filters?: Maybe<Array<Maybe<Filters>>>;
 };
+
+
+export type GetRunsByProjectIdLimitedToTimingQuery = (
+  { __typename?: 'Query' }
+  & { runs: Array<Maybe<(
+    { __typename?: 'Run' }
+    & Pick<Run, 'runId' | 'createdAt'>
+    & { meta?: Maybe<(
+      { __typename?: 'RunMeta' }
+      & Pick<RunMeta, 'ciBuildId' | 'projectId'>
+    )>, specs: Array<Maybe<(
+      { __typename?: 'FullRunSpec' }
+      & Pick<FullRunSpec, 'spec'>
+      & { results?: Maybe<(
+        { __typename?: 'InstanceResults' }
+        & { stats: (
+          { __typename?: 'InstanceStats' }
+          & Pick<InstanceStats, 'wallClockDuration'>
+        ) }
+      )> }
+    )>> }
+  )>> }
+);
 
 export type GetRunsFeedQueryVariables = {
   cursor?: Maybe<Scalars['String']>;
 };
 
-export type GetRunsFeedQuery = { __typename?: 'Query' } & {
-  runFeed: { __typename?: 'RunFeed' } & Pick<RunFeed, 'cursor' | 'hasMore'> & {
-      runs: Array<
-        { __typename?: 'Run' } & Pick<Run, 'runId' | 'createdAt'> & {
-            meta?: Maybe<
-              { __typename?: 'RunMeta' } & Pick<
-                RunMeta,
-                'ciBuildId' | 'projectId'
-              > & {
-                  commit?: Maybe<
-                    { __typename?: 'Commit' } & Pick<
-                      Commit,
-                      | 'sha'
-                      | 'branch'
-                      | 'remoteOrigin'
-                      | 'message'
-                      | 'authorEmail'
-                      | 'authorName'
-                    >
-                  >;
-                }
-            >;
-            specs: Array<
-              Maybe<
-                { __typename?: 'FullRunSpec' } & Pick<
-                  FullRunSpec,
-                  'spec' | 'instanceId' | 'claimed'
-                > & {
-                    results?: Maybe<
-                      { __typename?: 'InstanceResults' } & Pick<
-                        InstanceResults,
-                        'videoUrl'
-                      > & {
-                          cypressConfig?: Maybe<
-                            { __typename?: 'CypressConfig' } & Pick<
-                              CypressConfig,
-                              'video' | 'videoUploadOnPasses'
-                            >
-                          >;
-                          tests?: Maybe<
-                            Array<
-                              Maybe<
-                                { __typename?: 'InstanceTest' } & Pick<
-                                  InstanceTest,
-                                  'title' | 'state'
-                                >
-                              >
-                            >
-                          >;
-                          stats: { __typename?: 'InstanceStats' } & Pick<
-                            InstanceStats,
-                            | 'tests'
-                            | 'pending'
-                            | 'passes'
-                            | 'failures'
-                            | 'skipped'
-                            | 'suites'
-                            | 'wallClockDuration'
-                            | 'wallClockStartedAt'
-                            | 'wallClockEndedAt'
-                          >;
-                        }
-                    >;
-                  }
-              >
-            >;
-          }
-      >;
-    };
-};
+
+export type GetRunsFeedQuery = (
+  { __typename?: 'Query' }
+  & { runFeed: (
+    { __typename?: 'RunFeed' }
+    & Pick<RunFeed, 'cursor' | 'hasMore'>
+    & { runs: Array<(
+      { __typename?: 'Run' }
+      & Pick<Run, 'runId' | 'createdAt'>
+      & { meta?: Maybe<(
+        { __typename?: 'RunMeta' }
+        & Pick<RunMeta, 'ciBuildId' | 'projectId'>
+        & { commit?: Maybe<(
+          { __typename?: 'Commit' }
+          & Pick<Commit, 'sha' | 'branch' | 'remoteOrigin' | 'message' | 'authorEmail' | 'authorName'>
+        )> }
+      )>, specs: Array<Maybe<(
+        { __typename?: 'FullRunSpec' }
+        & Pick<FullRunSpec, 'spec' | 'instanceId' | 'claimed'>
+        & { results?: Maybe<(
+          { __typename?: 'InstanceResults' }
+          & Pick<InstanceResults, 'videoUrl'>
+          & { cypressConfig?: Maybe<(
+            { __typename?: 'CypressConfig' }
+            & Pick<CypressConfig, 'video' | 'videoUploadOnPasses'>
+          )>, tests?: Maybe<Array<Maybe<(
+            { __typename?: 'InstanceTest' }
+            & Pick<InstanceTest, 'title' | 'state'>
+          )>>>, stats: (
+            { __typename?: 'InstanceStats' }
+            & Pick<InstanceStats, 'tests' | 'pending' | 'passes' | 'failures' | 'skipped' | 'suites' | 'wallClockDuration' | 'wallClockStartedAt' | 'wallClockEndedAt'>
+          ) }
+        )> }
+      )>> }
+    )> }
+  ) }
+);
+
 
 export const DeleteRunDocument = gql`
-  mutation deleteRun($runId: ID!) {
-    deleteRun(runId: $runId) {
-      success
-      message
-      runIds
-    }
+    mutation deleteRun($runId: ID!) {
+  deleteRun(runId: $runId) {
+    success
+    message
+    runIds
   }
-`;
-export type DeleteRunMutationFn = ApolloReactCommon.MutationFunction<
-  DeleteRunMutation,
-  DeleteRunMutationVariables
->;
+}
+    `;
+export type DeleteRunMutationFn = ApolloReactCommon.MutationFunction<DeleteRunMutation, DeleteRunMutationVariables>;
 
 /**
  * __useDeleteRunMutation__
@@ -477,83 +406,68 @@ export type DeleteRunMutationFn = ApolloReactCommon.MutationFunction<
  *   },
  * });
  */
-export function useDeleteRunMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
-    DeleteRunMutation,
-    DeleteRunMutationVariables
-  >
-) {
-  return ApolloReactHooks.useMutation<
-    DeleteRunMutation,
-    DeleteRunMutationVariables
-  >(DeleteRunDocument, baseOptions);
-}
-export type DeleteRunMutationHookResult = ReturnType<
-  typeof useDeleteRunMutation
->;
-export type DeleteRunMutationResult = ApolloReactCommon.MutationResult<
-  DeleteRunMutation
->;
-export type DeleteRunMutationOptions = ApolloReactCommon.BaseMutationOptions<
-  DeleteRunMutation,
-  DeleteRunMutationVariables
->;
-export const GetInstanceDocument = gql`
-  query getInstance($instanceId: ID!) {
-    instance(id: $instanceId) {
-      instanceId
-      runId
-      spec
-      run {
-        meta {
-          ciBuildId
-          commit {
-            sha
-            branch
-            authorName
-            authorEmail
-            remoteOrigin
-            message
-          }
-        }
+export function useDeleteRunMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<DeleteRunMutation, DeleteRunMutationVariables>) {
+        return ApolloReactHooks.useMutation<DeleteRunMutation, DeleteRunMutationVariables>(DeleteRunDocument, baseOptions);
       }
-      results {
-        stats {
-          suites
-          tests
-          passes
-          pending
-          skipped
-          failures
-          wallClockDuration
-          wallClockStartedAt
-          wallClockEndedAt
+export type DeleteRunMutationHookResult = ReturnType<typeof useDeleteRunMutation>;
+export type DeleteRunMutationResult = ApolloReactCommon.MutationResult<DeleteRunMutation>;
+export type DeleteRunMutationOptions = ApolloReactCommon.BaseMutationOptions<DeleteRunMutation, DeleteRunMutationVariables>;
+export const GetInstanceDocument = gql`
+    query getInstance($instanceId: ID!) {
+  instance(id: $instanceId) {
+    instanceId
+    runId
+    spec
+    run {
+      meta {
+        ciBuildId
+        commit {
+          sha
+          branch
+          authorName
+          authorEmail
+          remoteOrigin
+          message
         }
-        tests {
-          testId
-          wallClockDuration
-          wallClockStartedAt
-          state
-          error
-          stack
-          title
-        }
-        screenshots {
-          testId
-          screenshotId
-          height
-          width
-          screenshotURL
-        }
-        cypressConfig {
-          video
-          videoUploadOnPasses
-        }
-        videoUrl
       }
     }
+    results {
+      stats {
+        suites
+        tests
+        passes
+        pending
+        skipped
+        failures
+        wallClockDuration
+        wallClockStartedAt
+        wallClockEndedAt
+      }
+      tests {
+        testId
+        wallClockDuration
+        wallClockStartedAt
+        state
+        error
+        stack
+        title
+      }
+      screenshots {
+        testId
+        screenshotId
+        height
+        width
+        screenshotURL
+      }
+      cypressConfig {
+        video
+        videoUploadOnPasses
+      }
+      videoUrl
+    }
   }
-`;
+}
+    `;
 
 /**
  * __useGetInstanceQuery__
@@ -571,39 +485,144 @@ export const GetInstanceDocument = gql`
  *   },
  * });
  */
-export function useGetInstanceQuery(
-  baseOptions?: ApolloReactHooks.QueryHookOptions<
-    GetInstanceQuery,
-    GetInstanceQueryVariables
-  >
-) {
-  return ApolloReactHooks.useQuery<GetInstanceQuery, GetInstanceQueryVariables>(
-    GetInstanceDocument,
-    baseOptions
-  );
-}
-export function useGetInstanceLazyQuery(
-  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
-    GetInstanceQuery,
-    GetInstanceQueryVariables
-  >
-) {
-  return ApolloReactHooks.useLazyQuery<
-    GetInstanceQuery,
-    GetInstanceQueryVariables
-  >(GetInstanceDocument, baseOptions);
-}
+export function useGetInstanceQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetInstanceQuery, GetInstanceQueryVariables>) {
+        return ApolloReactHooks.useQuery<GetInstanceQuery, GetInstanceQueryVariables>(GetInstanceDocument, baseOptions);
+      }
+export function useGetInstanceLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetInstanceQuery, GetInstanceQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<GetInstanceQuery, GetInstanceQueryVariables>(GetInstanceDocument, baseOptions);
+        }
 export type GetInstanceQueryHookResult = ReturnType<typeof useGetInstanceQuery>;
-export type GetInstanceLazyQueryHookResult = ReturnType<
-  typeof useGetInstanceLazyQuery
->;
-export type GetInstanceQueryResult = ApolloReactCommon.QueryResult<
-  GetInstanceQuery,
-  GetInstanceQueryVariables
->;
+export type GetInstanceLazyQueryHookResult = ReturnType<typeof useGetInstanceLazyQuery>;
+export type GetInstanceQueryResult = ApolloReactCommon.QueryResult<GetInstanceQuery, GetInstanceQueryVariables>;
 export const GetRunDocument = gql`
-  query getRun($runId: ID!) {
-    run(id: $runId) {
+    query getRun($runId: ID!) {
+  run(id: $runId) {
+    runId
+    createdAt
+    meta {
+      ciBuildId
+      projectId
+      commit {
+        sha
+        branch
+        remoteOrigin
+        message
+        authorEmail
+        authorName
+      }
+    }
+    specs {
+      spec
+      instanceId
+      claimed
+      claimedAt
+      results {
+        cypressConfig {
+          video
+          videoUploadOnPasses
+        }
+        videoUrl
+        tests {
+          title
+          state
+          wallClockDuration
+          wallClockStartedAt
+        }
+        stats {
+          tests
+          pending
+          passes
+          failures
+          skipped
+          suites
+          wallClockDuration
+          wallClockStartedAt
+          wallClockEndedAt
+        }
+      }
+    }
+  }
+}
+    `;
+
+/**
+ * __useGetRunQuery__
+ *
+ * To run a query within a React component, call `useGetRunQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetRunQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetRunQuery({
+ *   variables: {
+ *      runId: // value for 'runId'
+ *   },
+ * });
+ */
+export function useGetRunQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetRunQuery, GetRunQueryVariables>) {
+        return ApolloReactHooks.useQuery<GetRunQuery, GetRunQueryVariables>(GetRunDocument, baseOptions);
+      }
+export function useGetRunLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetRunQuery, GetRunQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<GetRunQuery, GetRunQueryVariables>(GetRunDocument, baseOptions);
+        }
+export type GetRunQueryHookResult = ReturnType<typeof useGetRunQuery>;
+export type GetRunLazyQueryHookResult = ReturnType<typeof useGetRunLazyQuery>;
+export type GetRunQueryResult = ApolloReactCommon.QueryResult<GetRunQuery, GetRunQueryVariables>;
+export const GetRunsByProjectIdLimitedToTimingDocument = gql`
+    query getRunsByProjectIdLimitedToTiming($orderDirection: OrderingOptions, $filters: [Filters]) {
+  runs(orderDirection: $orderDirection, filters: $filters) {
+    runId
+    createdAt
+    meta {
+      ciBuildId
+      projectId
+    }
+    specs {
+      spec
+      results {
+        stats {
+          wallClockDuration
+        }
+      }
+    }
+  }
+}
+    `;
+
+/**
+ * __useGetRunsByProjectIdLimitedToTimingQuery__
+ *
+ * To run a query within a React component, call `useGetRunsByProjectIdLimitedToTimingQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetRunsByProjectIdLimitedToTimingQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetRunsByProjectIdLimitedToTimingQuery({
+ *   variables: {
+ *      orderDirection: // value for 'orderDirection'
+ *      filters: // value for 'filters'
+ *   },
+ * });
+ */
+export function useGetRunsByProjectIdLimitedToTimingQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetRunsByProjectIdLimitedToTimingQuery, GetRunsByProjectIdLimitedToTimingQueryVariables>) {
+        return ApolloReactHooks.useQuery<GetRunsByProjectIdLimitedToTimingQuery, GetRunsByProjectIdLimitedToTimingQueryVariables>(GetRunsByProjectIdLimitedToTimingDocument, baseOptions);
+      }
+export function useGetRunsByProjectIdLimitedToTimingLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetRunsByProjectIdLimitedToTimingQuery, GetRunsByProjectIdLimitedToTimingQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<GetRunsByProjectIdLimitedToTimingQuery, GetRunsByProjectIdLimitedToTimingQueryVariables>(GetRunsByProjectIdLimitedToTimingDocument, baseOptions);
+        }
+export type GetRunsByProjectIdLimitedToTimingQueryHookResult = ReturnType<typeof useGetRunsByProjectIdLimitedToTimingQuery>;
+export type GetRunsByProjectIdLimitedToTimingLazyQueryHookResult = ReturnType<typeof useGetRunsByProjectIdLimitedToTimingLazyQuery>;
+export type GetRunsByProjectIdLimitedToTimingQueryResult = ApolloReactCommon.QueryResult<GetRunsByProjectIdLimitedToTimingQuery, GetRunsByProjectIdLimitedToTimingQueryVariables>;
+export const GetRunsFeedDocument = gql`
+    query getRunsFeed($cursor: String) {
+  runFeed(cursor: $cursor) {
+    cursor
+    hasMore
+    runs {
       runId
       createdAt
       meta {
@@ -622,7 +641,6 @@ export const GetRunDocument = gql`
         spec
         instanceId
         claimed
-        claimedAt
         results {
           cypressConfig {
             video
@@ -632,8 +650,6 @@ export const GetRunDocument = gql`
           tests {
             title
             state
-            wallClockDuration
-            wallClockStartedAt
           }
           stats {
             tests
@@ -650,103 +666,8 @@ export const GetRunDocument = gql`
       }
     }
   }
-`;
-
-/**
- * __useGetRunQuery__
- *
- * To run a query within a React component, call `useGetRunQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetRunQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetRunQuery({
- *   variables: {
- *      runId: // value for 'runId'
- *   },
- * });
- */
-export function useGetRunQuery(
-  baseOptions?: ApolloReactHooks.QueryHookOptions<
-    GetRunQuery,
-    GetRunQueryVariables
-  >
-) {
-  return ApolloReactHooks.useQuery<GetRunQuery, GetRunQueryVariables>(
-    GetRunDocument,
-    baseOptions
-  );
 }
-export function useGetRunLazyQuery(
-  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
-    GetRunQuery,
-    GetRunQueryVariables
-  >
-) {
-  return ApolloReactHooks.useLazyQuery<GetRunQuery, GetRunQueryVariables>(
-    GetRunDocument,
-    baseOptions
-  );
-}
-export type GetRunQueryHookResult = ReturnType<typeof useGetRunQuery>;
-export type GetRunLazyQueryHookResult = ReturnType<typeof useGetRunLazyQuery>;
-export type GetRunQueryResult = ApolloReactCommon.QueryResult<
-  GetRunQuery,
-  GetRunQueryVariables
->;
-export const GetRunsFeedDocument = gql`
-  query getRunsFeed($cursor: String) {
-    runFeed(cursor: $cursor) {
-      cursor
-      hasMore
-      runs {
-        runId
-        createdAt
-        meta {
-          ciBuildId
-          projectId
-          commit {
-            sha
-            branch
-            remoteOrigin
-            message
-            authorEmail
-            authorName
-          }
-        }
-        specs {
-          spec
-          instanceId
-          claimed
-          results {
-            cypressConfig {
-              video
-              videoUploadOnPasses
-            }
-            videoUrl
-            tests {
-              title
-              state
-            }
-            stats {
-              tests
-              pending
-              passes
-              failures
-              skipped
-              suites
-              wallClockDuration
-              wallClockStartedAt
-              wallClockEndedAt
-            }
-          }
-        }
-      }
-    }
-  }
-`;
+    `;
 
 /**
  * __useGetRunsFeedQuery__
@@ -764,33 +685,12 @@ export const GetRunsFeedDocument = gql`
  *   },
  * });
  */
-export function useGetRunsFeedQuery(
-  baseOptions?: ApolloReactHooks.QueryHookOptions<
-    GetRunsFeedQuery,
-    GetRunsFeedQueryVariables
-  >
-) {
-  return ApolloReactHooks.useQuery<GetRunsFeedQuery, GetRunsFeedQueryVariables>(
-    GetRunsFeedDocument,
-    baseOptions
-  );
-}
-export function useGetRunsFeedLazyQuery(
-  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
-    GetRunsFeedQuery,
-    GetRunsFeedQueryVariables
-  >
-) {
-  return ApolloReactHooks.useLazyQuery<
-    GetRunsFeedQuery,
-    GetRunsFeedQueryVariables
-  >(GetRunsFeedDocument, baseOptions);
-}
+export function useGetRunsFeedQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetRunsFeedQuery, GetRunsFeedQueryVariables>) {
+        return ApolloReactHooks.useQuery<GetRunsFeedQuery, GetRunsFeedQueryVariables>(GetRunsFeedDocument, baseOptions);
+      }
+export function useGetRunsFeedLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetRunsFeedQuery, GetRunsFeedQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<GetRunsFeedQuery, GetRunsFeedQueryVariables>(GetRunsFeedDocument, baseOptions);
+        }
 export type GetRunsFeedQueryHookResult = ReturnType<typeof useGetRunsFeedQuery>;
-export type GetRunsFeedLazyQueryHookResult = ReturnType<
-  typeof useGetRunsFeedLazyQuery
->;
-export type GetRunsFeedQueryResult = ApolloReactCommon.QueryResult<
-  GetRunsFeedQuery,
-  GetRunsFeedQueryVariables
->;
+export type GetRunsFeedLazyQueryHookResult = ReturnType<typeof useGetRunsFeedLazyQuery>;
+export type GetRunsFeedQueryResult = ApolloReactCommon.QueryResult<GetRunsFeedQuery, GetRunsFeedQueryVariables>;

--- a/packages/dashboard/src/generated/graphql.ts
+++ b/packages/dashboard/src/generated/graphql.ts
@@ -13,7 +13,7 @@ export type Scalars = {
 };
 
 export type Commit = {
-   __typename?: 'Commit';
+  __typename?: 'Commit';
   sha?: Maybe<Scalars['String']>;
   branch?: Maybe<Scalars['String']>;
   authorName?: Maybe<Scalars['String']>;
@@ -23,14 +23,13 @@ export type Commit = {
 };
 
 export type CypressConfig = {
-   __typename?: 'CypressConfig';
+  __typename?: 'CypressConfig';
   video: Scalars['Boolean'];
   videoUploadOnPasses: Scalars['Boolean'];
 };
 
-
 export type DeleteRunResponse = {
-   __typename?: 'DeleteRunResponse';
+  __typename?: 'DeleteRunResponse';
   success: Scalars['Boolean'];
   message: Scalars['String'];
   runIds: Array<Maybe<Scalars['ID']>>;
@@ -42,7 +41,7 @@ export type Filters = {
 };
 
 export type FullRunSpec = {
-   __typename?: 'FullRunSpec';
+  __typename?: 'FullRunSpec';
   spec: Scalars['String'];
   instanceId: Scalars['String'];
   claimed: Scalars['Boolean'];
@@ -51,7 +50,7 @@ export type FullRunSpec = {
 };
 
 export type Instance = {
-   __typename?: 'Instance';
+  __typename?: 'Instance';
   runId: Scalars['ID'];
   run: PartialRun;
   spec: Scalars['String'];
@@ -60,7 +59,7 @@ export type Instance = {
 };
 
 export type InstanceResults = {
-   __typename?: 'InstanceResults';
+  __typename?: 'InstanceResults';
   stats: InstanceStats;
   tests?: Maybe<Array<Maybe<InstanceTest>>>;
   error?: Maybe<Scalars['String']>;
@@ -72,7 +71,7 @@ export type InstanceResults = {
 };
 
 export type InstanceScreeshot = {
-   __typename?: 'InstanceScreeshot';
+  __typename?: 'InstanceScreeshot';
   screenshotId: Scalars['String'];
   name?: Maybe<Scalars['String']>;
   testId: Scalars['String'];
@@ -83,7 +82,7 @@ export type InstanceScreeshot = {
 };
 
 export type InstanceStats = {
-   __typename?: 'InstanceStats';
+  __typename?: 'InstanceStats';
   suites?: Maybe<Scalars['Int']>;
   tests?: Maybe<Scalars['Int']>;
   passes?: Maybe<Scalars['Int']>;
@@ -96,7 +95,7 @@ export type InstanceStats = {
 };
 
 export type InstanceTest = {
-   __typename?: 'InstanceTest';
+  __typename?: 'InstanceTest';
   testId: Scalars['String'];
   title?: Maybe<Array<Maybe<Scalars['String']>>>;
   state?: Maybe<Scalars['String']>;
@@ -108,22 +107,19 @@ export type InstanceTest = {
 };
 
 export type Mutation = {
-   __typename?: 'Mutation';
+  __typename?: 'Mutation';
   deleteRun: DeleteRunResponse;
   deleteRuns: DeleteRunResponse;
   deleteRunsInDateRange: DeleteRunResponse;
 };
 
-
 export type MutationDeleteRunArgs = {
   runId: Scalars['ID'];
 };
 
-
 export type MutationDeleteRunsArgs = {
   runIds: Array<Maybe<Scalars['ID']>>;
 };
-
 
 export type MutationDeleteRunsInDateRangeArgs = {
   startDate: Scalars['DateTime'];
@@ -132,11 +128,11 @@ export type MutationDeleteRunsInDateRangeArgs = {
 
 export enum OrderingOptions {
   Desc = 'DESC',
-  Asc = 'ASC'
+  Asc = 'ASC',
 }
 
 export type PartialRun = {
-   __typename?: 'PartialRun';
+  __typename?: 'PartialRun';
   runId: Scalars['ID'];
   createdAt: Scalars['DateTime'];
   meta?: Maybe<RunMeta>;
@@ -144,13 +140,12 @@ export type PartialRun = {
 };
 
 export type Query = {
-   __typename?: 'Query';
+  __typename?: 'Query';
   runs: Array<Maybe<Run>>;
   runFeed: RunFeed;
   run?: Maybe<Run>;
   instance?: Maybe<Instance>;
 };
-
 
 export type QueryRunsArgs = {
   orderDirection?: Maybe<OrderingOptions>;
@@ -158,23 +153,20 @@ export type QueryRunsArgs = {
   filters?: Maybe<Array<Maybe<Filters>>>;
 };
 
-
 export type QueryRunFeedArgs = {
   cursor?: Maybe<Scalars['String']>;
 };
 
-
 export type QueryRunArgs = {
   id: Scalars['ID'];
 };
-
 
 export type QueryInstanceArgs = {
   id: Scalars['ID'];
 };
 
 export type ReporterStats = {
-   __typename?: 'ReporterStats';
+  __typename?: 'ReporterStats';
   suites?: Maybe<Scalars['Int']>;
   tests?: Maybe<Scalars['Int']>;
   passes?: Maybe<Scalars['Int']>;
@@ -186,7 +178,7 @@ export type ReporterStats = {
 };
 
 export type Run = {
-   __typename?: 'Run';
+  __typename?: 'Run';
   runId: Scalars['ID'];
   createdAt: Scalars['DateTime'];
   meta?: Maybe<RunMeta>;
@@ -194,14 +186,14 @@ export type Run = {
 };
 
 export type RunFeed = {
-   __typename?: 'RunFeed';
+  __typename?: 'RunFeed';
   cursor: Scalars['String'];
   hasMore: Scalars['Boolean'];
   runs: Array<Run>;
 };
 
 export type RunMeta = {
-   __typename?: 'RunMeta';
+  __typename?: 'RunMeta';
   groupId?: Maybe<Scalars['String']>;
   ciBuildId?: Maybe<Scalars['String']>;
   projectId?: Maybe<Scalars['String']>;
@@ -209,7 +201,7 @@ export type RunMeta = {
 };
 
 export type RunSpec = {
-   __typename?: 'RunSpec';
+  __typename?: 'RunSpec';
   spec: Scalars['String'];
   instanceId: Scalars['String'];
   claimed: Scalars['Boolean'];
@@ -220,174 +212,295 @@ export type DeleteRunMutationVariables = {
   runId: Scalars['ID'];
 };
 
-
-export type DeleteRunMutation = (
-  { __typename?: 'Mutation' }
-  & { deleteRun: (
-    { __typename?: 'DeleteRunResponse' }
-    & Pick<DeleteRunResponse, 'success' | 'message' | 'runIds'>
-  ) }
-);
+export type DeleteRunMutation = { __typename?: 'Mutation' } & {
+  deleteRun: { __typename?: 'DeleteRunResponse' } & Pick<
+    DeleteRunResponse,
+    'success' | 'message' | 'runIds'
+  >;
+};
 
 export type GetInstanceQueryVariables = {
   instanceId: Scalars['ID'];
 };
 
-
-export type GetInstanceQuery = (
-  { __typename?: 'Query' }
-  & { instance?: Maybe<(
-    { __typename?: 'Instance' }
-    & Pick<Instance, 'instanceId' | 'runId' | 'spec'>
-    & { run: (
-      { __typename?: 'PartialRun' }
-      & { meta?: Maybe<(
-        { __typename?: 'RunMeta' }
-        & Pick<RunMeta, 'ciBuildId'>
-        & { commit?: Maybe<(
-          { __typename?: 'Commit' }
-          & Pick<Commit, 'sha' | 'branch' | 'authorName' | 'authorEmail' | 'remoteOrigin' | 'message'>
-        )> }
-      )> }
-    ), results?: Maybe<(
-      { __typename?: 'InstanceResults' }
-      & Pick<InstanceResults, 'videoUrl'>
-      & { stats: (
-        { __typename?: 'InstanceStats' }
-        & Pick<InstanceStats, 'suites' | 'tests' | 'passes' | 'pending' | 'skipped' | 'failures' | 'wallClockDuration' | 'wallClockStartedAt' | 'wallClockEndedAt'>
-      ), tests?: Maybe<Array<Maybe<(
-        { __typename?: 'InstanceTest' }
-        & Pick<InstanceTest, 'testId' | 'wallClockDuration' | 'wallClockStartedAt' | 'state' | 'error' | 'stack' | 'title'>
-      )>>>, screenshots: Array<(
-        { __typename?: 'InstanceScreeshot' }
-        & Pick<InstanceScreeshot, 'testId' | 'screenshotId' | 'height' | 'width' | 'screenshotURL'>
-      )>, cypressConfig?: Maybe<(
-        { __typename?: 'CypressConfig' }
-        & Pick<CypressConfig, 'video' | 'videoUploadOnPasses'>
-      )> }
-    )> }
-  )> }
-);
+export type GetInstanceQuery = { __typename?: 'Query' } & {
+  instance?: Maybe<
+    { __typename?: 'Instance' } & Pick<
+      Instance,
+      'instanceId' | 'runId' | 'spec'
+    > & {
+        run: { __typename?: 'PartialRun' } & {
+          meta?: Maybe<
+            { __typename?: 'RunMeta' } & Pick<RunMeta, 'ciBuildId'> & {
+                commit?: Maybe<
+                  { __typename?: 'Commit' } & Pick<
+                    Commit,
+                    | 'sha'
+                    | 'branch'
+                    | 'authorName'
+                    | 'authorEmail'
+                    | 'remoteOrigin'
+                    | 'message'
+                  >
+                >;
+              }
+          >;
+        };
+        results?: Maybe<
+          { __typename?: 'InstanceResults' } & Pick<
+            InstanceResults,
+            'videoUrl'
+          > & {
+              stats: { __typename?: 'InstanceStats' } & Pick<
+                InstanceStats,
+                | 'suites'
+                | 'tests'
+                | 'passes'
+                | 'pending'
+                | 'skipped'
+                | 'failures'
+                | 'wallClockDuration'
+                | 'wallClockStartedAt'
+                | 'wallClockEndedAt'
+              >;
+              tests?: Maybe<
+                Array<
+                  Maybe<
+                    { __typename?: 'InstanceTest' } & Pick<
+                      InstanceTest,
+                      | 'testId'
+                      | 'wallClockDuration'
+                      | 'wallClockStartedAt'
+                      | 'state'
+                      | 'error'
+                      | 'stack'
+                      | 'title'
+                    >
+                  >
+                >
+              >;
+              screenshots: Array<
+                { __typename?: 'InstanceScreeshot' } & Pick<
+                  InstanceScreeshot,
+                  | 'testId'
+                  | 'screenshotId'
+                  | 'height'
+                  | 'width'
+                  | 'screenshotURL'
+                >
+              >;
+              cypressConfig?: Maybe<
+                { __typename?: 'CypressConfig' } & Pick<
+                  CypressConfig,
+                  'video' | 'videoUploadOnPasses'
+                >
+              >;
+            }
+        >;
+      }
+  >;
+};
 
 export type GetRunQueryVariables = {
   runId: Scalars['ID'];
 };
 
-
-export type GetRunQuery = (
-  { __typename?: 'Query' }
-  & { run?: Maybe<(
-    { __typename?: 'Run' }
-    & Pick<Run, 'runId' | 'createdAt'>
-    & { meta?: Maybe<(
-      { __typename?: 'RunMeta' }
-      & Pick<RunMeta, 'ciBuildId' | 'projectId'>
-      & { commit?: Maybe<(
-        { __typename?: 'Commit' }
-        & Pick<Commit, 'sha' | 'branch' | 'remoteOrigin' | 'message' | 'authorEmail' | 'authorName'>
-      )> }
-    )>, specs: Array<Maybe<(
-      { __typename?: 'FullRunSpec' }
-      & Pick<FullRunSpec, 'spec' | 'instanceId' | 'claimed' | 'claimedAt'>
-      & { results?: Maybe<(
-        { __typename?: 'InstanceResults' }
-        & Pick<InstanceResults, 'videoUrl'>
-        & { cypressConfig?: Maybe<(
-          { __typename?: 'CypressConfig' }
-          & Pick<CypressConfig, 'video' | 'videoUploadOnPasses'>
-        )>, tests?: Maybe<Array<Maybe<(
-          { __typename?: 'InstanceTest' }
-          & Pick<InstanceTest, 'title' | 'state' | 'wallClockDuration' | 'wallClockStartedAt'>
-        )>>>, stats: (
-          { __typename?: 'InstanceStats' }
-          & Pick<InstanceStats, 'tests' | 'pending' | 'passes' | 'failures' | 'skipped' | 'suites' | 'wallClockDuration' | 'wallClockStartedAt' | 'wallClockEndedAt'>
-        ) }
-      )> }
-    )>> }
-  )> }
-);
+export type GetRunQuery = { __typename?: 'Query' } & {
+  run?: Maybe<
+    { __typename?: 'Run' } & Pick<Run, 'runId' | 'createdAt'> & {
+        meta?: Maybe<
+          { __typename?: 'RunMeta' } & Pick<
+            RunMeta,
+            'ciBuildId' | 'projectId'
+          > & {
+              commit?: Maybe<
+                { __typename?: 'Commit' } & Pick<
+                  Commit,
+                  | 'sha'
+                  | 'branch'
+                  | 'remoteOrigin'
+                  | 'message'
+                  | 'authorEmail'
+                  | 'authorName'
+                >
+              >;
+            }
+        >;
+        specs: Array<
+          Maybe<
+            { __typename?: 'FullRunSpec' } & Pick<
+              FullRunSpec,
+              'spec' | 'instanceId' | 'claimed' | 'claimedAt'
+            > & {
+                results?: Maybe<
+                  { __typename?: 'InstanceResults' } & Pick<
+                    InstanceResults,
+                    'videoUrl'
+                  > & {
+                      cypressConfig?: Maybe<
+                        { __typename?: 'CypressConfig' } & Pick<
+                          CypressConfig,
+                          'video' | 'videoUploadOnPasses'
+                        >
+                      >;
+                      tests?: Maybe<
+                        Array<
+                          Maybe<
+                            { __typename?: 'InstanceTest' } & Pick<
+                              InstanceTest,
+                              | 'title'
+                              | 'state'
+                              | 'wallClockDuration'
+                              | 'wallClockStartedAt'
+                            >
+                          >
+                        >
+                      >;
+                      stats: { __typename?: 'InstanceStats' } & Pick<
+                        InstanceStats,
+                        | 'tests'
+                        | 'pending'
+                        | 'passes'
+                        | 'failures'
+                        | 'skipped'
+                        | 'suites'
+                        | 'wallClockDuration'
+                        | 'wallClockStartedAt'
+                        | 'wallClockEndedAt'
+                      >;
+                    }
+                >;
+              }
+          >
+        >;
+      }
+  >;
+};
 
 export type GetRunsByProjectIdLimitedToTimingQueryVariables = {
   orderDirection?: Maybe<OrderingOptions>;
   filters?: Maybe<Array<Maybe<Filters>>>;
 };
 
-
-export type GetRunsByProjectIdLimitedToTimingQuery = (
-  { __typename?: 'Query' }
-  & { runs: Array<Maybe<(
-    { __typename?: 'Run' }
-    & Pick<Run, 'runId' | 'createdAt'>
-    & { meta?: Maybe<(
-      { __typename?: 'RunMeta' }
-      & Pick<RunMeta, 'ciBuildId' | 'projectId'>
-    )>, specs: Array<Maybe<(
-      { __typename?: 'FullRunSpec' }
-      & Pick<FullRunSpec, 'spec'>
-      & { results?: Maybe<(
-        { __typename?: 'InstanceResults' }
-        & { stats: (
-          { __typename?: 'InstanceStats' }
-          & Pick<InstanceStats, 'wallClockDuration'>
-        ) }
-      )> }
-    )>> }
-  )>> }
-);
+export type GetRunsByProjectIdLimitedToTimingQuery = {
+  __typename?: 'Query';
+} & {
+  runs: Array<
+    Maybe<
+      { __typename?: 'Run' } & Pick<Run, 'runId' | 'createdAt'> & {
+          meta?: Maybe<
+            { __typename?: 'RunMeta' } & Pick<
+              RunMeta,
+              'ciBuildId' | 'projectId'
+            >
+          >;
+          specs: Array<
+            Maybe<
+              { __typename?: 'FullRunSpec' } & Pick<FullRunSpec, 'spec'> & {
+                  results?: Maybe<
+                    { __typename?: 'InstanceResults' } & {
+                      stats: { __typename?: 'InstanceStats' } & Pick<
+                        InstanceStats,
+                        'wallClockDuration'
+                      >;
+                    }
+                  >;
+                }
+            >
+          >;
+        }
+    >
+  >;
+};
 
 export type GetRunsFeedQueryVariables = {
   cursor?: Maybe<Scalars['String']>;
 };
 
-
-export type GetRunsFeedQuery = (
-  { __typename?: 'Query' }
-  & { runFeed: (
-    { __typename?: 'RunFeed' }
-    & Pick<RunFeed, 'cursor' | 'hasMore'>
-    & { runs: Array<(
-      { __typename?: 'Run' }
-      & Pick<Run, 'runId' | 'createdAt'>
-      & { meta?: Maybe<(
-        { __typename?: 'RunMeta' }
-        & Pick<RunMeta, 'ciBuildId' | 'projectId'>
-        & { commit?: Maybe<(
-          { __typename?: 'Commit' }
-          & Pick<Commit, 'sha' | 'branch' | 'remoteOrigin' | 'message' | 'authorEmail' | 'authorName'>
-        )> }
-      )>, specs: Array<Maybe<(
-        { __typename?: 'FullRunSpec' }
-        & Pick<FullRunSpec, 'spec' | 'instanceId' | 'claimed'>
-        & { results?: Maybe<(
-          { __typename?: 'InstanceResults' }
-          & Pick<InstanceResults, 'videoUrl'>
-          & { cypressConfig?: Maybe<(
-            { __typename?: 'CypressConfig' }
-            & Pick<CypressConfig, 'video' | 'videoUploadOnPasses'>
-          )>, tests?: Maybe<Array<Maybe<(
-            { __typename?: 'InstanceTest' }
-            & Pick<InstanceTest, 'title' | 'state'>
-          )>>>, stats: (
-            { __typename?: 'InstanceStats' }
-            & Pick<InstanceStats, 'tests' | 'pending' | 'passes' | 'failures' | 'skipped' | 'suites' | 'wallClockDuration' | 'wallClockStartedAt' | 'wallClockEndedAt'>
-          ) }
-        )> }
-      )>> }
-    )> }
-  ) }
-);
-
+export type GetRunsFeedQuery = { __typename?: 'Query' } & {
+  runFeed: { __typename?: 'RunFeed' } & Pick<RunFeed, 'cursor' | 'hasMore'> & {
+      runs: Array<
+        { __typename?: 'Run' } & Pick<Run, 'runId' | 'createdAt'> & {
+            meta?: Maybe<
+              { __typename?: 'RunMeta' } & Pick<
+                RunMeta,
+                'ciBuildId' | 'projectId'
+              > & {
+                  commit?: Maybe<
+                    { __typename?: 'Commit' } & Pick<
+                      Commit,
+                      | 'sha'
+                      | 'branch'
+                      | 'remoteOrigin'
+                      | 'message'
+                      | 'authorEmail'
+                      | 'authorName'
+                    >
+                  >;
+                }
+            >;
+            specs: Array<
+              Maybe<
+                { __typename?: 'FullRunSpec' } & Pick<
+                  FullRunSpec,
+                  'spec' | 'instanceId' | 'claimed'
+                > & {
+                    results?: Maybe<
+                      { __typename?: 'InstanceResults' } & Pick<
+                        InstanceResults,
+                        'videoUrl'
+                      > & {
+                          cypressConfig?: Maybe<
+                            { __typename?: 'CypressConfig' } & Pick<
+                              CypressConfig,
+                              'video' | 'videoUploadOnPasses'
+                            >
+                          >;
+                          tests?: Maybe<
+                            Array<
+                              Maybe<
+                                { __typename?: 'InstanceTest' } & Pick<
+                                  InstanceTest,
+                                  'title' | 'state'
+                                >
+                              >
+                            >
+                          >;
+                          stats: { __typename?: 'InstanceStats' } & Pick<
+                            InstanceStats,
+                            | 'tests'
+                            | 'pending'
+                            | 'passes'
+                            | 'failures'
+                            | 'skipped'
+                            | 'suites'
+                            | 'wallClockDuration'
+                            | 'wallClockStartedAt'
+                            | 'wallClockEndedAt'
+                          >;
+                        }
+                    >;
+                  }
+              >
+            >;
+          }
+      >;
+    };
+};
 
 export const DeleteRunDocument = gql`
-    mutation deleteRun($runId: ID!) {
-  deleteRun(runId: $runId) {
-    success
-    message
-    runIds
+  mutation deleteRun($runId: ID!) {
+    deleteRun(runId: $runId) {
+      success
+      message
+      runIds
+    }
   }
-}
-    `;
-export type DeleteRunMutationFn = ApolloReactCommon.MutationFunction<DeleteRunMutation, DeleteRunMutationVariables>;
+`;
+export type DeleteRunMutationFn = ApolloReactCommon.MutationFunction<
+  DeleteRunMutation,
+  DeleteRunMutationVariables
+>;
 
 /**
  * __useDeleteRunMutation__
@@ -406,68 +519,83 @@ export type DeleteRunMutationFn = ApolloReactCommon.MutationFunction<DeleteRunMu
  *   },
  * });
  */
-export function useDeleteRunMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<DeleteRunMutation, DeleteRunMutationVariables>) {
-        return ApolloReactHooks.useMutation<DeleteRunMutation, DeleteRunMutationVariables>(DeleteRunDocument, baseOptions);
-      }
-export type DeleteRunMutationHookResult = ReturnType<typeof useDeleteRunMutation>;
-export type DeleteRunMutationResult = ApolloReactCommon.MutationResult<DeleteRunMutation>;
-export type DeleteRunMutationOptions = ApolloReactCommon.BaseMutationOptions<DeleteRunMutation, DeleteRunMutationVariables>;
+export function useDeleteRunMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    DeleteRunMutation,
+    DeleteRunMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    DeleteRunMutation,
+    DeleteRunMutationVariables
+  >(DeleteRunDocument, baseOptions);
+}
+export type DeleteRunMutationHookResult = ReturnType<
+  typeof useDeleteRunMutation
+>;
+export type DeleteRunMutationResult = ApolloReactCommon.MutationResult<
+  DeleteRunMutation
+>;
+export type DeleteRunMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  DeleteRunMutation,
+  DeleteRunMutationVariables
+>;
 export const GetInstanceDocument = gql`
-    query getInstance($instanceId: ID!) {
-  instance(id: $instanceId) {
-    instanceId
-    runId
-    spec
-    run {
-      meta {
-        ciBuildId
-        commit {
-          sha
-          branch
-          authorName
-          authorEmail
-          remoteOrigin
-          message
+  query getInstance($instanceId: ID!) {
+    instance(id: $instanceId) {
+      instanceId
+      runId
+      spec
+      run {
+        meta {
+          ciBuildId
+          commit {
+            sha
+            branch
+            authorName
+            authorEmail
+            remoteOrigin
+            message
+          }
         }
       }
-    }
-    results {
-      stats {
-        suites
-        tests
-        passes
-        pending
-        skipped
-        failures
-        wallClockDuration
-        wallClockStartedAt
-        wallClockEndedAt
+      results {
+        stats {
+          suites
+          tests
+          passes
+          pending
+          skipped
+          failures
+          wallClockDuration
+          wallClockStartedAt
+          wallClockEndedAt
+        }
+        tests {
+          testId
+          wallClockDuration
+          wallClockStartedAt
+          state
+          error
+          stack
+          title
+        }
+        screenshots {
+          testId
+          screenshotId
+          height
+          width
+          screenshotURL
+        }
+        cypressConfig {
+          video
+          videoUploadOnPasses
+        }
+        videoUrl
       }
-      tests {
-        testId
-        wallClockDuration
-        wallClockStartedAt
-        state
-        error
-        stack
-        title
-      }
-      screenshots {
-        testId
-        screenshotId
-        height
-        width
-        screenshotURL
-      }
-      cypressConfig {
-        video
-        videoUploadOnPasses
-      }
-      videoUrl
     }
   }
-}
-    `;
+`;
 
 /**
  * __useGetInstanceQuery__
@@ -485,144 +613,39 @@ export const GetInstanceDocument = gql`
  *   },
  * });
  */
-export function useGetInstanceQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetInstanceQuery, GetInstanceQueryVariables>) {
-        return ApolloReactHooks.useQuery<GetInstanceQuery, GetInstanceQueryVariables>(GetInstanceDocument, baseOptions);
-      }
-export function useGetInstanceLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetInstanceQuery, GetInstanceQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<GetInstanceQuery, GetInstanceQueryVariables>(GetInstanceDocument, baseOptions);
-        }
+export function useGetInstanceQuery(
+  baseOptions?: ApolloReactHooks.QueryHookOptions<
+    GetInstanceQuery,
+    GetInstanceQueryVariables
+  >
+) {
+  return ApolloReactHooks.useQuery<GetInstanceQuery, GetInstanceQueryVariables>(
+    GetInstanceDocument,
+    baseOptions
+  );
+}
+export function useGetInstanceLazyQuery(
+  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
+    GetInstanceQuery,
+    GetInstanceQueryVariables
+  >
+) {
+  return ApolloReactHooks.useLazyQuery<
+    GetInstanceQuery,
+    GetInstanceQueryVariables
+  >(GetInstanceDocument, baseOptions);
+}
 export type GetInstanceQueryHookResult = ReturnType<typeof useGetInstanceQuery>;
-export type GetInstanceLazyQueryHookResult = ReturnType<typeof useGetInstanceLazyQuery>;
-export type GetInstanceQueryResult = ApolloReactCommon.QueryResult<GetInstanceQuery, GetInstanceQueryVariables>;
+export type GetInstanceLazyQueryHookResult = ReturnType<
+  typeof useGetInstanceLazyQuery
+>;
+export type GetInstanceQueryResult = ApolloReactCommon.QueryResult<
+  GetInstanceQuery,
+  GetInstanceQueryVariables
+>;
 export const GetRunDocument = gql`
-    query getRun($runId: ID!) {
-  run(id: $runId) {
-    runId
-    createdAt
-    meta {
-      ciBuildId
-      projectId
-      commit {
-        sha
-        branch
-        remoteOrigin
-        message
-        authorEmail
-        authorName
-      }
-    }
-    specs {
-      spec
-      instanceId
-      claimed
-      claimedAt
-      results {
-        cypressConfig {
-          video
-          videoUploadOnPasses
-        }
-        videoUrl
-        tests {
-          title
-          state
-          wallClockDuration
-          wallClockStartedAt
-        }
-        stats {
-          tests
-          pending
-          passes
-          failures
-          skipped
-          suites
-          wallClockDuration
-          wallClockStartedAt
-          wallClockEndedAt
-        }
-      }
-    }
-  }
-}
-    `;
-
-/**
- * __useGetRunQuery__
- *
- * To run a query within a React component, call `useGetRunQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetRunQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetRunQuery({
- *   variables: {
- *      runId: // value for 'runId'
- *   },
- * });
- */
-export function useGetRunQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetRunQuery, GetRunQueryVariables>) {
-        return ApolloReactHooks.useQuery<GetRunQuery, GetRunQueryVariables>(GetRunDocument, baseOptions);
-      }
-export function useGetRunLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetRunQuery, GetRunQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<GetRunQuery, GetRunQueryVariables>(GetRunDocument, baseOptions);
-        }
-export type GetRunQueryHookResult = ReturnType<typeof useGetRunQuery>;
-export type GetRunLazyQueryHookResult = ReturnType<typeof useGetRunLazyQuery>;
-export type GetRunQueryResult = ApolloReactCommon.QueryResult<GetRunQuery, GetRunQueryVariables>;
-export const GetRunsByProjectIdLimitedToTimingDocument = gql`
-    query getRunsByProjectIdLimitedToTiming($orderDirection: OrderingOptions, $filters: [Filters]) {
-  runs(orderDirection: $orderDirection, filters: $filters) {
-    runId
-    createdAt
-    meta {
-      ciBuildId
-      projectId
-    }
-    specs {
-      spec
-      results {
-        stats {
-          wallClockDuration
-        }
-      }
-    }
-  }
-}
-    `;
-
-/**
- * __useGetRunsByProjectIdLimitedToTimingQuery__
- *
- * To run a query within a React component, call `useGetRunsByProjectIdLimitedToTimingQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetRunsByProjectIdLimitedToTimingQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetRunsByProjectIdLimitedToTimingQuery({
- *   variables: {
- *      orderDirection: // value for 'orderDirection'
- *      filters: // value for 'filters'
- *   },
- * });
- */
-export function useGetRunsByProjectIdLimitedToTimingQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetRunsByProjectIdLimitedToTimingQuery, GetRunsByProjectIdLimitedToTimingQueryVariables>) {
-        return ApolloReactHooks.useQuery<GetRunsByProjectIdLimitedToTimingQuery, GetRunsByProjectIdLimitedToTimingQueryVariables>(GetRunsByProjectIdLimitedToTimingDocument, baseOptions);
-      }
-export function useGetRunsByProjectIdLimitedToTimingLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetRunsByProjectIdLimitedToTimingQuery, GetRunsByProjectIdLimitedToTimingQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<GetRunsByProjectIdLimitedToTimingQuery, GetRunsByProjectIdLimitedToTimingQueryVariables>(GetRunsByProjectIdLimitedToTimingDocument, baseOptions);
-        }
-export type GetRunsByProjectIdLimitedToTimingQueryHookResult = ReturnType<typeof useGetRunsByProjectIdLimitedToTimingQuery>;
-export type GetRunsByProjectIdLimitedToTimingLazyQueryHookResult = ReturnType<typeof useGetRunsByProjectIdLimitedToTimingLazyQuery>;
-export type GetRunsByProjectIdLimitedToTimingQueryResult = ApolloReactCommon.QueryResult<GetRunsByProjectIdLimitedToTimingQuery, GetRunsByProjectIdLimitedToTimingQueryVariables>;
-export const GetRunsFeedDocument = gql`
-    query getRunsFeed($cursor: String) {
-  runFeed(cursor: $cursor) {
-    cursor
-    hasMore
-    runs {
+  query getRun($runId: ID!) {
+    run(id: $runId) {
       runId
       createdAt
       meta {
@@ -641,6 +664,7 @@ export const GetRunsFeedDocument = gql`
         spec
         instanceId
         claimed
+        claimedAt
         results {
           cypressConfig {
             video
@@ -650,6 +674,8 @@ export const GetRunsFeedDocument = gql`
           tests {
             title
             state
+            wallClockDuration
+            wallClockStartedAt
           }
           stats {
             tests
@@ -666,8 +692,176 @@ export const GetRunsFeedDocument = gql`
       }
     }
   }
+`;
+
+/**
+ * __useGetRunQuery__
+ *
+ * To run a query within a React component, call `useGetRunQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetRunQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetRunQuery({
+ *   variables: {
+ *      runId: // value for 'runId'
+ *   },
+ * });
+ */
+export function useGetRunQuery(
+  baseOptions?: ApolloReactHooks.QueryHookOptions<
+    GetRunQuery,
+    GetRunQueryVariables
+  >
+) {
+  return ApolloReactHooks.useQuery<GetRunQuery, GetRunQueryVariables>(
+    GetRunDocument,
+    baseOptions
+  );
 }
-    `;
+export function useGetRunLazyQuery(
+  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
+    GetRunQuery,
+    GetRunQueryVariables
+  >
+) {
+  return ApolloReactHooks.useLazyQuery<GetRunQuery, GetRunQueryVariables>(
+    GetRunDocument,
+    baseOptions
+  );
+}
+export type GetRunQueryHookResult = ReturnType<typeof useGetRunQuery>;
+export type GetRunLazyQueryHookResult = ReturnType<typeof useGetRunLazyQuery>;
+export type GetRunQueryResult = ApolloReactCommon.QueryResult<
+  GetRunQuery,
+  GetRunQueryVariables
+>;
+export const GetRunsByProjectIdLimitedToTimingDocument = gql`
+  query getRunsByProjectIdLimitedToTiming(
+    $orderDirection: OrderingOptions
+    $filters: [Filters]
+  ) {
+    runs(orderDirection: $orderDirection, filters: $filters) {
+      runId
+      createdAt
+      meta {
+        ciBuildId
+        projectId
+      }
+      specs {
+        spec
+        results {
+          stats {
+            wallClockDuration
+          }
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * __useGetRunsByProjectIdLimitedToTimingQuery__
+ *
+ * To run a query within a React component, call `useGetRunsByProjectIdLimitedToTimingQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetRunsByProjectIdLimitedToTimingQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetRunsByProjectIdLimitedToTimingQuery({
+ *   variables: {
+ *      orderDirection: // value for 'orderDirection'
+ *      filters: // value for 'filters'
+ *   },
+ * });
+ */
+export function useGetRunsByProjectIdLimitedToTimingQuery(
+  baseOptions?: ApolloReactHooks.QueryHookOptions<
+    GetRunsByProjectIdLimitedToTimingQuery,
+    GetRunsByProjectIdLimitedToTimingQueryVariables
+  >
+) {
+  return ApolloReactHooks.useQuery<
+    GetRunsByProjectIdLimitedToTimingQuery,
+    GetRunsByProjectIdLimitedToTimingQueryVariables
+  >(GetRunsByProjectIdLimitedToTimingDocument, baseOptions);
+}
+export function useGetRunsByProjectIdLimitedToTimingLazyQuery(
+  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
+    GetRunsByProjectIdLimitedToTimingQuery,
+    GetRunsByProjectIdLimitedToTimingQueryVariables
+  >
+) {
+  return ApolloReactHooks.useLazyQuery<
+    GetRunsByProjectIdLimitedToTimingQuery,
+    GetRunsByProjectIdLimitedToTimingQueryVariables
+  >(GetRunsByProjectIdLimitedToTimingDocument, baseOptions);
+}
+export type GetRunsByProjectIdLimitedToTimingQueryHookResult = ReturnType<
+  typeof useGetRunsByProjectIdLimitedToTimingQuery
+>;
+export type GetRunsByProjectIdLimitedToTimingLazyQueryHookResult = ReturnType<
+  typeof useGetRunsByProjectIdLimitedToTimingLazyQuery
+>;
+export type GetRunsByProjectIdLimitedToTimingQueryResult = ApolloReactCommon.QueryResult<
+  GetRunsByProjectIdLimitedToTimingQuery,
+  GetRunsByProjectIdLimitedToTimingQueryVariables
+>;
+export const GetRunsFeedDocument = gql`
+  query getRunsFeed($cursor: String) {
+    runFeed(cursor: $cursor) {
+      cursor
+      hasMore
+      runs {
+        runId
+        createdAt
+        meta {
+          ciBuildId
+          projectId
+          commit {
+            sha
+            branch
+            remoteOrigin
+            message
+            authorEmail
+            authorName
+          }
+        }
+        specs {
+          spec
+          instanceId
+          claimed
+          results {
+            cypressConfig {
+              video
+              videoUploadOnPasses
+            }
+            videoUrl
+            tests {
+              title
+              state
+            }
+            stats {
+              tests
+              pending
+              passes
+              failures
+              skipped
+              suites
+              wallClockDuration
+              wallClockStartedAt
+              wallClockEndedAt
+            }
+          }
+        }
+      }
+    }
+  }
+`;
 
 /**
  * __useGetRunsFeedQuery__
@@ -685,12 +879,33 @@ export const GetRunsFeedDocument = gql`
  *   },
  * });
  */
-export function useGetRunsFeedQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetRunsFeedQuery, GetRunsFeedQueryVariables>) {
-        return ApolloReactHooks.useQuery<GetRunsFeedQuery, GetRunsFeedQueryVariables>(GetRunsFeedDocument, baseOptions);
-      }
-export function useGetRunsFeedLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetRunsFeedQuery, GetRunsFeedQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<GetRunsFeedQuery, GetRunsFeedQueryVariables>(GetRunsFeedDocument, baseOptions);
-        }
+export function useGetRunsFeedQuery(
+  baseOptions?: ApolloReactHooks.QueryHookOptions<
+    GetRunsFeedQuery,
+    GetRunsFeedQueryVariables
+  >
+) {
+  return ApolloReactHooks.useQuery<GetRunsFeedQuery, GetRunsFeedQueryVariables>(
+    GetRunsFeedDocument,
+    baseOptions
+  );
+}
+export function useGetRunsFeedLazyQuery(
+  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
+    GetRunsFeedQuery,
+    GetRunsFeedQueryVariables
+  >
+) {
+  return ApolloReactHooks.useLazyQuery<
+    GetRunsFeedQuery,
+    GetRunsFeedQueryVariables
+  >(GetRunsFeedDocument, baseOptions);
+}
 export type GetRunsFeedQueryHookResult = ReturnType<typeof useGetRunsFeedQuery>;
-export type GetRunsFeedLazyQueryHookResult = ReturnType<typeof useGetRunsFeedLazyQuery>;
-export type GetRunsFeedQueryResult = ApolloReactCommon.QueryResult<GetRunsFeedQuery, GetRunsFeedQueryVariables>;
+export type GetRunsFeedLazyQueryHookResult = ReturnType<
+  typeof useGetRunsFeedLazyQuery
+>;
+export type GetRunsFeedQueryResult = ApolloReactCommon.QueryResult<
+  GetRunsFeedQuery,
+  GetRunsFeedQueryVariables
+>;

--- a/packages/dashboard/src/views/RunDetailsView.tsx
+++ b/packages/dashboard/src/views/RunDetailsView.tsx
@@ -3,8 +3,31 @@ import { useAutoRefresh } from '@src/hooks/useAutoRefresh';
 import React from 'react';
 import { RunDetails } from '../components/run/details';
 import { RunSummary } from '../components/run/summary';
-import { useGetRunQuery, useGetRunsByProjectIdLimitedToTimingQuery } from '../generated/graphql';
+import {
+  GetRunsByProjectIdLimitedToTimingQuery,
+  useGetRunQuery,
+  useGetRunsByProjectIdLimitedToTimingQuery,
+} from '../generated/graphql';
 
+function getSpecTimingsList(
+  runsWithTimingData: GetRunsByProjectIdLimitedToTimingQuery
+) {
+  return runsWithTimingData.runs.reduce<Record<string, number[]>>(
+    (accumulator, runData) => {
+      runData?.specs.forEach((spec) => {
+        if (!spec) {
+          return accumulator;
+        }
+        accumulator[spec.spec] = accumulator[spec.spec] || [];
+        if (spec?.results?.stats?.wallClockDuration) {
+          accumulator[spec.spec].push(spec?.results?.stats?.wallClockDuration);
+        }
+      });
+      return accumulator;
+    },
+    {}
+  );
+}
 type RunDetailsViewProps = {
   match: {
     params: {
@@ -17,38 +40,31 @@ export function RunDetailsView({
     params: { id },
   },
 }: RunDetailsViewProps): React.ReactNode {
-  let propertySpecHeuristics;
   const apollo = useApolloClient();
 
   const [shouldAutoRefresh] = useAutoRefresh();
 
-  const { loading: runLoading, error: runError, data: runData } = useGetRunQuery({
+  const {
+    loading: runLoading,
+    error: runError,
+    data: runData,
+  } = useGetRunQuery({
     variables: { runId: id },
     pollInterval: shouldAutoRefresh ? 1500 : undefined,
   });
 
-  const { data: runsWithTimingData } = useGetRunsByProjectIdLimitedToTimingQuery({
+  const {
+    data: runsWithTimingData,
+  } = useGetRunsByProjectIdLimitedToTimingQuery({
     variables: {
       filters: [
         {
           key: 'meta.projectId',
-          value: runData?.run?.meta?.projectId
-        }
-      ]
-    }
+          value: runData?.run?.meta?.projectId,
+        },
+      ],
+    },
   });
-
-  if (runsWithTimingData) {
-    propertySpecHeuristics = runsWithTimingData.runs.reduce((accumulator, runData)=>{
-      runData.specs.forEach((spec)=>{
-        accumulator[spec.spec] = accumulator[spec.spec] || [];
-        if ( spec?.results?.stats?.wallClockDuration ) {
-          accumulator[spec.spec].push(spec?.results?.stats?.wallClockDuration)
-        }
-      });
-      return accumulator; 
-    },{})
-  }
 
   if (runLoading) return <p>Loading...</p>;
   if (runError) return <p>{runError.toString()}</p>;
@@ -74,8 +90,8 @@ export function RunDetailsView({
       navStructure: [
         {
           __typename: 'NavStructureItem',
-          label: runData.run!.meta!.ciBuildId,
-          link: `run/${runData.run!.runId}`,
+          label: runData.run.meta?.ciBuildId,
+          link: `run/${runData.run.runId}`,
         },
       ],
     },
@@ -84,7 +100,12 @@ export function RunDetailsView({
   return (
     <>
       <RunSummary run={runData.run} />
-      <RunDetails run={runData.run} propertySpecHeuristics={propertySpecHeuristics} />
+      <RunDetails
+        run={runData.run}
+        propertySpecHeuristics={
+          runsWithTimingData ? getSpecTimingsList(runsWithTimingData) : []
+        }
+      />
     </>
   );
 }

--- a/packages/dashboard/src/views/RunDetailsView.tsx
+++ b/packages/dashboard/src/views/RunDetailsView.tsx
@@ -3,7 +3,7 @@ import { useAutoRefresh } from '@src/hooks/useAutoRefresh';
 import React from 'react';
 import { RunDetails } from '../components/run/details';
 import { RunSummary } from '../components/run/summary';
-import { useGetRunQuery } from '../generated/graphql';
+import { useGetRunQuery, useGetRunsByProjectIdLimitedToTimingQuery } from '../generated/graphql';
 
 type RunDetailsViewProps = {
   match: {
@@ -17,20 +17,44 @@ export function RunDetailsView({
     params: { id },
   },
 }: RunDetailsViewProps): React.ReactNode {
+  let propertySpecHeuristics;
   const apollo = useApolloClient();
 
   const [shouldAutoRefresh] = useAutoRefresh();
 
-  const { loading, error, data } = useGetRunQuery({
+  const { loading: runLoading, error: runError, data: runData } = useGetRunQuery({
     variables: { runId: id },
     pollInterval: shouldAutoRefresh ? 1500 : undefined,
   });
 
-  if (loading) return <p>Loading...</p>;
-  if (error) return <p>{error.toString()}</p>;
-  if (!data) return <p>No data</p>;
+  const { data: runsWithTimingData } = useGetRunsByProjectIdLimitedToTimingQuery({
+    variables: {
+      filters: [
+        {
+          key: 'meta.projectId',
+          value: runData?.run?.meta?.projectId
+        }
+      ]
+    }
+  });
 
-  if (!data.run) {
+  if (runsWithTimingData) {
+    propertySpecHeuristics = runsWithTimingData.runs.reduce((accumulator, runData)=>{
+      runData.specs.forEach((spec)=>{
+        accumulator[spec.spec] = accumulator[spec.spec] || [];
+        if ( spec?.results?.stats?.wallClockDuration ) {
+          accumulator[spec.spec].push(spec?.results?.stats?.wallClockDuration)
+        }
+      });
+      return accumulator; 
+    },{})
+  }
+
+  if (runLoading) return <p>Loading...</p>;
+  if (runError) return <p>{runError.toString()}</p>;
+  if (!runData) return <p>No data</p>;
+
+  if (!runData.run) {
     apollo.writeData({
       data: {
         navStructure: [
@@ -50,8 +74,8 @@ export function RunDetailsView({
       navStructure: [
         {
           __typename: 'NavStructureItem',
-          label: data.run!.meta!.ciBuildId,
-          link: `run/${data.run!.runId}`,
+          label: runData.run!.meta!.ciBuildId,
+          link: `run/${runData.run!.runId}`,
         },
       ],
     },
@@ -59,8 +83,8 @@ export function RunDetailsView({
 
   return (
     <>
-      <RunSummary run={data.run} />
-      <RunDetails run={data.run} />
+      <RunSummary run={runData.run} />
+      <RunDetails run={runData.run} propertySpecHeuristics={propertySpecHeuristics} />
     </>
   );
 }

--- a/packages/dashboard/src/views/getRunsByProjectIdLimitedToTiming.graphql
+++ b/packages/dashboard/src/views/getRunsByProjectIdLimitedToTiming.graphql
@@ -1,0 +1,24 @@
+query getRunsByProjectIdLimitedToTiming(
+  $orderDirection: OrderingOptions
+  $filters: [Filters]
+) {
+  runs (
+    orderDirection: $orderDirection
+    filters: $filters
+  ) {
+    runId
+    createdAt
+    meta {
+      ciBuildId
+      projectId
+    }
+    specs {
+      spec
+      results {
+        stats {
+          wallClockDuration
+        }
+      }
+    }
+  }
+}

--- a/packages/dashboard/src/views/getRunsByProjectIdLimitedToTiming.graphql
+++ b/packages/dashboard/src/views/getRunsByProjectIdLimitedToTiming.graphql
@@ -2,10 +2,7 @@ query getRunsByProjectIdLimitedToTiming(
   $orderDirection: OrderingOptions
   $filters: [Filters]
 ) {
-  runs (
-    orderDirection: $orderDirection
-    filters: $filters
-  ) {
+  runs(orderDirection: $orderDirection, filters: $filters) {
     runId
     createdAt
     meta {

--- a/packages/director/src/screenshots/minio/minio.ts
+++ b/packages/director/src/screenshots/minio/minio.ts
@@ -1,18 +1,26 @@
-import * as Minio from 'minio';
-import { MINIO_BUCKET, MINIO_ACCESS_KEY, MINIO_SECRET_KEY, MINIO_READ_URL_PREFIX, MINIO_ENDPOINT, MINIO_PORT, MINIO_URL, MINIO_USESSL } from './config';
-import { S3SignedUploadResult } from './types';
 import { AssetUploadInstruction } from '@src/types';
+import * as Minio from 'minio';
+import {
+  MINIO_ACCESS_KEY,
+  MINIO_BUCKET,
+  MINIO_ENDPOINT,
+  MINIO_PORT,
+  MINIO_READ_URL_PREFIX,
+  MINIO_SECRET_KEY,
+  MINIO_URL,
+  MINIO_USESSL,
+} from './config';
+import { S3SignedUploadResult } from './types';
 
 const BUCKET_URL = `${MINIO_URL}:${MINIO_PORT}/${MINIO_BUCKET}`;
-const ImageContentType = 'image/png';
 const VideoContentType = 'video/mp4';
 
 const minioClient = new Minio.Client({
   endPoint: MINIO_ENDPOINT,
   port: +MINIO_PORT,
-  useSSL: (MINIO_USESSL == 'true'),
+  useSSL: MINIO_USESSL == 'true',
   accessKey: MINIO_ACCESS_KEY,
-  secretKey: MINIO_SECRET_KEY
+  secretKey: MINIO_SECRET_KEY,
 });
 
 interface GetUploadURLParams {
@@ -21,14 +29,7 @@ interface GetUploadURLParams {
 }
 export const getUploadUrl = async ({
   key,
-  ContentType = ImageContentType,
 }: GetUploadURLParams): Promise<S3SignedUploadResult> => {
-  const s3Params = {
-    Bucket: MINIO_BUCKET,
-    Key: key,
-    ContentType,
-  };
-
   return new Promise((resolve, reject) => {
     minioClient.presignedPutObject(
       MINIO_BUCKET,


### PR DESCRIPTION
The idea here is to give you an estimate of how long each spec is going to take to run. This could also be used to add heuristics to a run. But that is way more ambiguous. Since you could make an estimate on how long all the specs will run in tandem. Or based on having 5 test runners. Or based on all in parallel. This needs more thought. I think I good guess most of the time would be getting the earliest spec start time and latest spec end time for the last 5 runs and averaging that time gap but 🤷  it does not cover everycase.

![Screen Shot 2020-09-01 at 10 20 00 AM](https://user-images.githubusercontent.com/5297942/91880728-b0b47c80-ec3d-11ea-9a81-a882279ed71f.png)

